### PR TITLE
react-query for blocklist fetching and caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/icons-material": "^5.14.16",
         "@mui/material": "^5.14.20",
         "@mui/styles": "^5.14.20",
+        "@tanstack/react-query": "^4.36.1",
         "ag-grid-community": "^31.0.2",
         "ag-grid-react": "^31.0.3",
         "esbuild": "^0.20.0",
@@ -972,6 +973,43 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.36.1.tgz",
+      "integrity": "sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.36.1.tgz",
+      "integrity": "sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "4.36.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -1687,6 +1725,15 @@
       "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
       "dependencies": {
         "multiformats": "^9.4.2"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@mui/icons-material": "^5.14.16",
     "@mui/material": "^5.14.20",
     "@mui/styles": "^5.14.20",
+    "@tanstack/react-query": "^4.36.1",
     "ag-grid-community": "^31.0.2",
     "ag-grid-react": "^31.0.3",
     "esbuild": "^0.20.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "prettier": {
+    "singleQuote": true
+  },
   "dependencies": {
     "@atproto/api": "^0.10.4",
     "@emotion/react": "^11.11.1",

--- a/src/api/blocklist.js
+++ b/src/api/blocklist.js
@@ -3,84 +3,47 @@
 import { unwrapShortHandle, v1APIPrefix, xAPIKey } from '.';
 import { parseNumberWithCommas, unwrapClearSkyURL } from './core';
 import { resolveHandleOrDID } from './resolve-handle-or-did';
-
-const blocklistFetchQueued = new Map();
-let blocklistDebounce = 0;
+import { useInfiniteQuery } from '@tanstack/react-query';
 
 /**
  * @param {string} handleOrDID
  */
-export function blocklist(handleOrDID) {
-  if (blocklistFetchQueued.has(handleOrDID)) return blocklistFetchQueued.get(handleOrDID);
-
-  let generator = blocklistCall(handleOrDID, 'blocklist');
-  blocklistFetchQueued.set(handleOrDID, generator);
-
-  clearTimeout(blocklistDebounce);
-  blocklistDebounce = setTimeout(() => blocklistFetchQueued.delete(handleOrDID), 1000);
-
-  return generator;
-}
-
-const singleBlocklistFetchQueued = new Map();
-let singleBlocklistDebounce = 0;
-
-/**
- * @param {string} handleOrDID
- */
-export function singleBlocklist(handleOrDID) {
-  if (singleBlocklistFetchQueued.has(handleOrDID)) return singleBlocklistFetchQueued.get(handleOrDID);
-
-  let generator = blocklistCall(handleOrDID, 'single-blocklist');
-
-  singleBlocklistFetchQueued.set(handleOrDID, generator);
-
-  clearTimeout(singleBlocklistDebounce);
-  singleBlocklistDebounce = setTimeout(() => singleBlocklistFetchQueued.delete(handleOrDID), 1000);
-
-  return generator;
+export function useBlocklist(handleOrDID) {
+  return useInfiniteQuery({
+    queryKey: ['blocklist', handleOrDID],
+    queryFn: ({ pageParam = 1 }) =>
+      blocklistCall(handleOrDID, 'blocklist', pageParam),
+    getNextPageParam: (lastPage, pages) => lastPage.nextPage,
+  });
 }
 
 /**
- * @typedef {{
- *  shortDID: string,
- *  api: string,
- *  count: number,
- *  nextPage: number,
- *  blocklist: BlockedByRecord[]
- * }} BlockCacheEntry
+ * @param {string} handleOrDID
  */
-
-/**
- * @type {{ [key: string]: BlockCacheEntry }}
- */
-const blockApiResultCache = {};
+export function useSingleBlocklist(handleOrDID) {
+  return useInfiniteQuery({
+    queryKey: ['single-blocklist', handleOrDID],
+    queryFn: ({ pageParam = 1 }) =>
+      blocklistCall(handleOrDID, 'single-blocklist', pageParam),
+    getNextPageParam: (lastPage, pages) => lastPage.nextPage,
+  });
+}
 
 /**
  * @param {string} handleOrDID
- * @param {string} api
- * @returns {AsyncGenerator<{
+ * @param {"blocklist" | "single-blocklist"} api
+ * @param {number} currentPage
+ * @returns {Promise<{
  *    count: number,
- *    nextPage: number,
+ *    nextPage: number | null,
  *    blocklist: BlockedByRecord[]
  * }>}
  */
-async function* blocklistCall(handleOrDID, api) {
+export async function blocklistCall(handleOrDID, api, currentPage = 1) {
   const resolved = await resolveHandleOrDID(handleOrDID);
 
-  if (!resolved) throw new Error('Could not resolve handle or DID: ' + handleOrDID);
-
-  const key = resolved.shortDID + '/' + api;
-  let cacheEntry = blockApiResultCache[key];
-  if (cacheEntry) {
-    yield {
-      count: cacheEntry.count,
-      nextPage: cacheEntry.nextPage,
-      blocklist: cacheEntry.blocklist
-    };
-
-    if (!cacheEntry.nextPage) return;
-  }
+  if (!resolved)
+    throw new Error('Could not resolve handle or DID: ' + handleOrDID);
 
   /**
    * @typedef {{
@@ -96,40 +59,21 @@ async function* blocklistCall(handleOrDID, api) {
   const handleURL =
     unwrapClearSkyURL(v1APIPrefix + api + '/') +
     unwrapShortHandle(resolved.shortHandle);
-  
-  let nextPageNumber = cacheEntry?.nextPage || 1;
-  while (true) {
 
-    /** @type {SingleBlocklistResponse} */
-    const pageResponse = await fetch(
-      nextPageNumber === 1 ? handleURL : handleURL + '/' + nextPageNumber,
-      { headers: { 'X-API-Key': xAPIKey } }).then(x => x.json());
+  /** @type {SingleBlocklistResponse} */
+  const pageResponse = await fetch(
+    currentPage === 1 ? handleURL : handleURL + '/' + currentPage,
+    { headers: { 'X-API-Key': xAPIKey } }
+  ).then((x) => x.json());
 
-    let pages = parseNumberWithCommas(pageResponse.data.pages) || 1;
-    let count = parseNumberWithCommas(pageResponse.data.count) || 0;
+  let pages = parseNumberWithCommas(pageResponse.data.pages) || 1;
+  let count = parseNumberWithCommas(pageResponse.data.count) || 0;
 
-    const chunk = pageResponse.data.blocklist;
+  const chunk = pageResponse.data.blocklist;
 
-    if (cacheEntry) {
-      cacheEntry.blocklist = cacheEntry.blocklist.concat(chunk);
-    } else {
-      blockApiResultCache[key] = cacheEntry = {
-        shortDID: resolved.shortDID,
-        api,
-        count,
-        nextPage: 0,
-        blocklist: chunk
-      };
-    }
-    cacheEntry.count = count;
-    cacheEntry.nextPage = nextPageNumber = nextPageNumber >= pages ? 0 : nextPageNumber + 1;
-
-    yield {
-      count,
-      nextPage: cacheEntry.nextPage,
-      blocklist: cacheEntry.blocklist
-    };
-
-    if (!cacheEntry.nextPage) break;
-  }
+  return {
+    count,
+    nextPage: pages === currentPage ? null : currentPage + 1,
+    blocklist: chunk,
+  };
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -5,7 +5,7 @@ export { dashboardStats } from './dashboard-stats';
 export { postHistory } from './post-history';
 export { resolveHandleOrDID } from './resolve-handle-or-did';
 export { searchHandle } from './search';
-export { singleBlocklist, blocklist } from './blocklist';
+export { useSingleBlocklist, useBlocklist } from './blocklist';
 
 export const xAPIKey = '';
 

--- a/src/app.js
+++ b/src/app.js
@@ -7,6 +7,7 @@ import {
   RouterProvider,
 } from "react-router-dom";
 import { createTheme, ThemeProvider } from '@mui/material';
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
 import { AgGridReact } from 'ag-grid-react'; // React Grid Logic
 import "ag-grid-community/styles/ag-grid.css"; // Core CSS
@@ -89,16 +90,18 @@ function showApp() {
     },
   });
 
+  const queryClient = new QueryClient();
+
   console.log('React createRoot/render');
   ReactDOM.createRoot(root).render(
       <React.StrictMode>
         <ThemeProvider theme={theme}>
-          <>
+          <QueryClientProvider client={queryClient}>
             <RouterProvider router={router}/>
             <div className='bluethernal-llc-watermark'>
               © 2024 Bluethernal LLC
             </div>
-          </>
+          </QueryClientProvider>
         </ThemeProvider>
       </React.StrictMode>
 

--- a/src/detail-panels/block-panel-generic/block-panel-generic.js
+++ b/src/detail-panels/block-panel-generic/block-panel-generic.js
@@ -1,11 +1,11 @@
 // @ts-check
 
-import React, { useState } from 'react';
+import React from 'react';
 
 import { TableChart, TableRows } from '@mui/icons-material';
 import SearchIcon from '@mui/icons-material/Search';
 import { Button, CircularProgress } from '@mui/material';
-import { useSearchParams } from 'react-router-dom';
+// import { useSearchParams } from 'react-router-dom';
 
 import {
   isPromise,
@@ -13,9 +13,9 @@ import {
   useSingleBlocklist,
   unwrapShortHandle,
 } from '../../api';
-import { SearchHeaderDebounced } from '../history/search-header';
+// import { SearchHeaderDebounced } from '../history/search-header';
 import { ListView } from './list-view';
-import { TableView } from './table-view';
+// import { TableView } from './table-view';
 import { VisibleWithDelay } from '../../common-components/visible';
 
 import './block-panel-generic.css';
@@ -41,18 +41,18 @@ export function BlockPanelGeneric({
 
   const blocklistPages = data?.pages;
 
-  const [tableView, setTableView] = React.useState(false);
+  // const [tableView, setTableView] = React.useState(false);
 
   const blocklist = blocklistPages?.flatMap((page) => {
     return page.blocklist;
   });
   const count = blocklistPages?.[0]?.count;
 
-  const [searchParams, setSearchParams] = useSearchParams();
+  // const [searchParams, setSearchParams] = useSearchParams();
   // const [tick, setTick] = useState(0);
-  const search = (searchParams.get('q') || '').trim();
+  // const search = (searchParams.get('q') || '').trim();
 
-  const [showSearch, setShowSearch] = useState(!!search);
+  // const [showSearch, setShowSearch] = useState(!!search);
 
   // const filteredBlocklist =
   //   !search || !blocklist
@@ -68,30 +68,31 @@ export function BlockPanelGeneric({
         minHeight: '100%',
       }}
     >
-      <SearchHeaderDebounced
+      {/* <SearchHeaderDebounced
         style={showSearch ? undefined : { display: 'none' }}
         label={' ' + localise('Search', { uk: 'Пошук' })}
         setQ
-      />
+      /> */}
       <PanelHeader
         count={count}
         blocklist={blocklist}
         header={header}
-        showSearch={showSearch}
+        // Ironically this hides the search button
+        showSearch={true}
         // setShowSearch={setShowSearch}
         // onShowSearch={() => setShowSearch(true)}
-        onToggleView={() => setTableView(!tableView)}
-        tableView={tableView}
+        // onToggleView={() => setTableView(!tableView)}
+        // tableView={tableView}
       />
       {isLoading ? (
         <p style={{ padding: '0.5em', opacity: '0.5' }}>
           <CircularProgress size="1em" /> Loading...
         </p>
-      ) : tableView ? (
-        <TableView account={account} blocklist={blocklist} />
       ) : (
+        //tableView ? (<TableView account={account} blocklist={blocklist} />) : (
         <ListView account={account} blocklist={blocklist} />
       )}
+      {/* )} */}
       {hasNextPage ? (
         <VisibleWithDelay
           // needs to be delayed because the list view initially
@@ -145,17 +146,19 @@ class PanelHeader extends React.Component {
               <SearchIcon />
             </Button>
           )}
-          <Button
-            title={localise('Toggle table view', {
-              uk: 'Перемкнути вигляд таблиці/списку',
-            })}
-            variant="contained"
-            size="small"
-            className="panel-toggle-table"
-            onClick={this.props.onToggleView}
-          >
-            {this.props.tableView ? <TableRows /> : <TableChart />}
-          </Button>
+          {this.props.onToggleView ? (
+            <Button
+              title={localise('Toggle table view', {
+                uk: 'Перемкнути вигляд таблиці/списку',
+              })}
+              variant="contained"
+              size="small"
+              className="panel-toggle-table"
+              onClick={this.props.onToggleView}
+            >
+              {this.props.tableView ? <TableRows /> : <TableChart />}
+            </Button>
+          ) : null}
         </span>
       </h3>
     );

--- a/src/detail-panels/block-panel-generic/block-panel-generic.js
+++ b/src/detail-panels/block-panel-generic/block-panel-generic.js
@@ -48,11 +48,11 @@ export function BlockPanelGeneric({
   });
   const count = blocklistPages?.[0]?.count;
 
-  // const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   // const [tick, setTick] = useState(0);
-  // const search = (searchParams.get("q") || "").trim();
+  const search = (searchParams.get('q') || '').trim();
 
-  // const [showSearch, setShowSearch] = useState(!!search);
+  const [showSearch, setShowSearch] = useState(!!search);
 
   // const filteredBlocklist =
   //   !search || !blocklist
@@ -68,16 +68,16 @@ export function BlockPanelGeneric({
         minHeight: '100%',
       }}
     >
-      {/* <SearchHeaderDebounced
+      <SearchHeaderDebounced
         style={showSearch ? undefined : { display: 'none' }}
-        label={' ' + localise('Search', {uk: 'Пошук'})}
-        setQ /> */}
+        label={' ' + localise('Search', { uk: 'Пошук' })}
+        setQ
+      />
       <PanelHeader
         count={count}
         blocklist={blocklist}
         header={header}
-        // this actually hides the search icon?
-        showSearch={true}
+        showSearch={showSearch}
         // setShowSearch={setShowSearch}
         // onShowSearch={() => setShowSearch(true)}
         onToggleView={() => setTableView(!tableView)}

--- a/src/detail-panels/blocked-by/index.js
+++ b/src/detail-panels/blocked-by/index.js
@@ -1,8 +1,6 @@
 // @ts-check
 
-import React from 'react';
-
-import { singleBlocklist } from '../../api';
+import { useSingleBlocklist } from '../../api';
 import { BlockPanelGeneric } from '../block-panel-generic';
 import { localise } from '../../localisation';
 
@@ -10,7 +8,7 @@ export function BlockedByPanel({ account }) {
   return (
     <BlockPanelGeneric
       className='blocked-by-panel'
-      fetch={singleBlocklist}
+      useBlocklistQuery={useSingleBlocklist}
       account={account}
       header={({ count }) => <>{localise('Blocked by', { uk: 'Блокують' })} <span>{count.toLocaleString()}:</span></>} />
   );

--- a/src/detail-panels/blocking/index.js
+++ b/src/detail-panels/blocking/index.js
@@ -1,8 +1,6 @@
 // @ts-check
 
-import React from 'react';
-
-import { blocklist } from '../../api';
+import { useBlocklist } from '../../api';
 import { BlockPanelGeneric } from '../block-panel-generic';
 import { localise } from '../../localisation';
 
@@ -10,7 +8,7 @@ export function BlockingPanel({ account }) {
   return (
     <BlockPanelGeneric
       className='blocking-panel'
-      fetch={blocklist}
+      useBlocklistQuery={useBlocklist}
       account={account}
       header={({ count }) => <>{localise('Blocking', { uk: 'Блокує' })} <span>{count.toLocaleString()}:</span></>} />
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "lib": ["DOM", "ES2020"],
         "target": "es2018",
         "jsx": "react-jsx",
         "module": "NodeNext",


### PR DESCRIPTION
This switches over to react-query (aka tanstack query) to manage fetch/cache behavior of blocklists. Only one page will load initially. If more pages are available, the next will begin loading after a user scrolls to the bottom of the current list.

![image](https://github.com/user-attachments/assets/58e6907e-71c9-45ad-894e-e470c577a719)

This also removes the search functionality, as it will be inaccurate as long as we aren't loading the complete list of blocks in the client. In the future we can restore search behavior somehow, ideally via server-side call, but perhaps conditionally whenever all pages have been loaded?

Closes #80 
Closes #59
Begins progress on #122