### PR TITLE
blocklist should always be an array

### DIFF
--- a/src/detail-panels/block-panel-generic/block-panel-generic.js
+++ b/src/detail-panels/block-panel-generic/block-panel-generic.js
@@ -45,7 +45,7 @@ export function BlockPanelGeneric({
 
   const blocklist = blocklistPages?.flatMap((page) => {
     return page.blocklist;
-  });
+  }) || [];
   const count = blocklistPages?.[0]?.count;
 
   // const [searchParams, setSearchParams] = useSearchParams();


### PR DESCRIPTION
This should prevent the “blocklist is undefined” error reported in discord by always making sure blocklist is defined!