### PR TITLE
Change history to be default tab for profiles

### DIFF
--- a/src/detail-panels/layout.js
+++ b/src/detail-panels/layout.js
@@ -18,7 +18,7 @@ import { Lists } from './lists';
 import { getHandleHistory } from '../api/handle-history';
 import { forAwait } from '../common-components/for-await';
 
-export const accountTabs = /** @type {const} */(['blocking', 'blocked-by', 'lists', 'history']);
+export const accountTabs = /** @type {const} */(['history', 'blocking', 'blocked-by', 'lists']);
 
 export function AccountLayout() {
 


### PR DESCRIPTION
This changes the default landing tab from blocking to history so that the block API isn't hit initially for each profile visit.