### PR TITLE
resolve blocklists directly from a user's pds

### DIFF
--- a/src/api/blocklist.js
+++ b/src/api/blocklist.js
@@ -1,37 +1,70 @@
 // @ts-check
 
-import { unwrapShortHandle, v1APIPrefix, xAPIKey } from '.';
+import { unwrapShortDID, unwrapShortHandle, v1APIPrefix, xAPIKey } from '.';
 import { parseNumberWithCommas, unwrapClearSkyURL } from './core';
-import { resolveHandleOrDID } from './resolve-handle-or-did';
+import { usePdsUrl } from './pds';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
 /**
- * @param {string} handleOrDID
+ * @param {string} did
  */
-export function useBlocklist(handleOrDID) {
+export function useBlocklist(did) {
+  const fullDid = unwrapShortDID(did);
+
+  const { pdsUrl } = usePdsUrl(fullDid);
+
   return useInfiniteQuery({
-    queryKey: ['blocklist', handleOrDID],
-    queryFn: ({ pageParam = 1 }) =>
-      blocklistCall(handleOrDID, 'blocklist', pageParam),
-    getNextPageParam: (lastPage, pages) => lastPage.nextPage,
+    enabled: !!(pdsUrl && fullDid),
+    queryKey: ['blocks-from-pds', pdsUrl, fullDid],
+    queryFn: ({ pageParam = undefined }) =>
+      getBlocksFromPds(pdsUrl, fullDid, pageParam),
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
   });
 }
 
 /**
- * @param {string} handleOrDID
+ *
+ * @param {string} pdsHost
+ * @param {string} fullDid
+ * @param {string} [cursor]
  */
-export function useSingleBlocklist(handleOrDID) {
+async function getBlocksFromPds(pdsHost, fullDid, cursor) {
+  let queryUrl = `${pdsHost}/xrpc/com.atproto.repo.listRecords?repo=${fullDid}&limit=50&collection=app.bsky.graph.block`;
+  if (cursor) {
+    queryUrl += `&cursor=${cursor}`;
+  }
+  /** @typedef {{ uri: string; cid: string; value: { $type: "app.bsky.graph.block"; subject: string; createdAt: string }}} AtBlockRecord */
+  /** @type {{ records: Array<AtBlockRecord>; cursor: string }} */
+  const { records, cursor: nextCursor } = await fetch(queryUrl).then((x) =>
+    x.json()
+  );
+
+  return {
+    nextCursor: records.length < 50 ? null : nextCursor,
+    blocklist: records.map((record) => ({
+      did: record.value.subject,
+      blocked_date: record.value.createdAt,
+    })),
+  };
+}
+
+/**
+ * @param {string} did
+ */
+export function useSingleBlocklist(did) {
+  const fullDid = unwrapShortDID(did);
   return useInfiniteQuery({
-    queryKey: ['single-blocklist', handleOrDID],
+    enabled: !!fullDid,
+    queryKey: ['single-blocklist', fullDid],
     queryFn: ({ pageParam = 1 }) =>
-      blocklistCall(handleOrDID, 'single-blocklist', pageParam),
-    getNextPageParam: (lastPage, pages) => lastPage.nextPage,
+      blocklistCall(fullDid, 'single-blocklist', pageParam),
+    getNextPageParam: (lastPage) => lastPage.nextPage,
   });
 }
 
 /**
- * @param {string} handleOrDID
- * @param {"blocklist" | "single-blocklist"} api
+ * @param {string} did
+ * @param {"single-blocklist"} api
  * @param {number} currentPage
  * @returns {Promise<{
  *    count: number,
@@ -39,12 +72,7 @@ export function useSingleBlocklist(handleOrDID) {
  *    blocklist: BlockedByRecord[]
  * }>}
  */
-export async function blocklistCall(handleOrDID, api, currentPage = 1) {
-  const resolved = await resolveHandleOrDID(handleOrDID);
-
-  if (!resolved)
-    throw new Error('Could not resolve handle or DID: ' + handleOrDID);
-
+async function blocklistCall(did, api, currentPage = 1) {
   /**
    * @typedef {{
    *  data: {
@@ -56,9 +84,7 @@ export async function blocklistCall(handleOrDID, api, currentPage = 1) {
    *  status: boolean
    * }} SingleBlocklistResponse */
 
-  const handleURL =
-    unwrapClearSkyURL(v1APIPrefix + api + '/') +
-    unwrapShortHandle(resolved.shortHandle);
+  const handleURL = unwrapClearSkyURL(v1APIPrefix + api + '/') + did;
 
   /** @type {SingleBlocklistResponse} */
   const pageResponse = await fetch(

--- a/src/api/pds.js
+++ b/src/api/pds.js
@@ -1,0 +1,42 @@
+// @ts-check
+
+import { useQuery } from '@tanstack/react-query';
+
+/** @typedef {{ alsoKnownAs: Array<string>; service: Array<{ id: string; type: string; serviceEndpoint: string }> }} PlcRecord */
+
+/**
+ *
+ * @param {string} did
+ * @returns {import('@tanstack/react-query').UseQueryResult<PlcRecord>}
+ */
+export function usePlcRecord(did) {
+  return useQuery({
+    enabled: !!did,
+    queryKey: ['plc.directory', did],
+    queryFn: () =>
+      fetch(`https://plc.directory/${encodeURIComponent(did)}`).then((x) =>
+        x.json()
+      ),
+  });
+}
+
+/**
+ *
+ * @param {string} did
+ */
+export function usePdsUrl(did) {
+  const { status, error, data } = usePlcRecord(did);
+  /** @type {string | undefined} */
+  let pdsUrl;
+  if (status === 'success') {
+    const pds = data.service.find(
+      (s) => s.type === 'AtprotoPersonalDataServer' && !!s.serviceEndpoint
+    );
+    pdsUrl = pds?.serviceEndpoint;
+  }
+  return {
+    status,
+    error,
+    pdsUrl,
+  };
+}

--- a/src/api/resolve-handle-or-did.js
+++ b/src/api/resolve-handle-or-did.js
@@ -1,12 +1,32 @@
 // @ts-check
 /// <reference path="../types.d.ts" />
 
-import { getProfileBlobUrl, isPromise, likelyDID, shortenDID, shortenHandle, unwrapShortDID, unwrapShortHandle } from '.';
+import { useQuery } from '@tanstack/react-query';
+import {
+  isPromise,
+  likelyDID,
+  shortenDID,
+  shortenHandle,
+  unwrapShortDID,
+  unwrapShortHandle,
+} from '.';
 import { atClient } from './core';
 import { throttledAsyncCache } from './throttled-async-cache';
 
 /**
- * 
+ *
+ * @param {string} handleOrDID
+ */
+export function useResolveHandleOrDid(handleOrDID) {
+  return useQuery({
+    enabled: !!handleOrDID,
+    queryKey: ['resolveHandleOrDid', handleOrDID],
+    queryFn: () => resolveDIDCache(handleOrDID),
+  });
+}
+
+/**
+ *
  * @typedef {{
  *  did: string,
  *  handle: string,
@@ -27,76 +47,81 @@ import { throttledAsyncCache } from './throttled-async-cache';
  * }} ProfileRecord
  */
 
-const resolveHandleCache = throttledAsyncCache(async (handle) => {
-  const resolved = await atClient.com.atproto.identity.resolveHandle({
-    handle: unwrapShortHandle(handle)
-  });
+const resolveHandleCache = throttledAsyncCache(
+  async (/** @type {string} */ handle) => {
+    const resolved = await atClient.com.atproto.identity.resolveHandle({
+      handle: unwrapShortHandle(handle),
+    });
 
-  if (!resolved.data.did) throw new Error('Handle did not resolve: ' + handle);
-  return shortenDID(resolved.data.did);
-});
+    if (!resolved.data.did)
+      throw new Error('Handle did not resolve: ' + handle);
+    return shortenDID(resolved.data.did);
+  }
+);
 
-const resolveDIDCache = throttledAsyncCache(async (did) => {
-  const fullDID = unwrapShortDID(did);
-  const shortDID = shortenDID(did);
+const resolveDIDCache = throttledAsyncCache(
+  async (/** @type {string} */ did) => {
+    const fullDID = unwrapShortDID(did);
+    const shortDID = shortenDID(did);
 
-  const resolveHandlePublicApi = fetch(
-    'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=' + fullDID
-  ).then(x => x.json());
+    const resolveHandlePublicApi = fetch(
+      'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=' +
+        fullDID
+    ).then((x) => x.json());
 
-  // const describePromise = atClient.com.atproto.repo.describeRepo({
-  //   repo: fullDID
-  // });
+    // const describePromise = atClient.com.atproto.repo.describeRepo({
+    //   repo: fullDID
+    // });
 
-  // const profilePromise = atClient.com.atproto.repo.listRecords({
-  //   collection: 'app.bsky.actor.profile',
-  //   repo: fullDID
-  // });
+    // const profilePromise = atClient.com.atproto.repo.listRecords({
+    //   collection: 'app.bsky.actor.profile',
+    //   repo: fullDID
+    // });
 
-  /** @type {ProfileRecord} */
-  const profileRecord = await resolveHandlePublicApi;
+    /** @type {ProfileRecord} */
+    const profileRecord = await resolveHandlePublicApi;
 
-  //const [describe, profile] = await Promise.all([describePromise, profilePromise]);
+    //const [describe, profile] = await Promise.all([describePromise, profilePromise]);
 
-  // if (!describe.data.handle) throw new Error('DID does not have a handle: ' + did);
+    // if (!describe.data.handle) throw new Error('DID does not have a handle: ' + did);
 
-  const shortHandle = shortenHandle(profileRecord.handle) || '*' + fullDID + '*';
+    const shortHandle =
+      shortenHandle(profileRecord.handle) || '*' + fullDID + '*';
 
-  /* @type {*} */
-  //const profileRec = profile.data.records?.filter(rec => rec.value)[0]?.value;
-  // const avatarUrl = getProfileBlobUrl(fullDID, profileRec?.avatar?.ref?.toString());
-  // const bannerUrl = getProfileBlobUrl(fullDID, profileRec?.banner?.ref?.toString());
-  // const displayName = profileRec?.displayName;
-  // const description = profileRec?.description;
-  // const obscurePublicRecords = detectObscurePublicRecordsFlag(profileRec);
+    /* @type {*} */
+    //const profileRec = profile.data.records?.filter(rec => rec.value)[0]?.value;
+    // const avatarUrl = getProfileBlobUrl(fullDID, profileRec?.avatar?.ref?.toString());
+    // const bannerUrl = getProfileBlobUrl(fullDID, profileRec?.banner?.ref?.toString());
+    // const displayName = profileRec?.displayName;
+    // const description = profileRec?.description;
+    // const obscurePublicRecords = detectObscurePublicRecordsFlag(profileRec);
 
-  const avatarUrl = profileRecord.avatar;
-  const bannerUrl = profileRecord.banner;
-  const displayName = profileRecord.displayName;
-  const description = profileRecord.description;
-  const obscurePublicRecords = detectObscurePublicRecordsFlag(profileRecord);
+    const avatarUrl = profileRecord.avatar;
+    const bannerUrl = profileRecord.banner;
+    const displayName = profileRecord.displayName;
+    const description = profileRecord.description;
+    const obscurePublicRecords = detectObscurePublicRecordsFlag(profileRecord);
 
-  const profileDetails = {
-    shortDID,
-    shortHandle,
-    avatarUrl,
-    bannerUrl,
-    displayName,
-    description
-  };
-  if (typeof obscurePublicRecords !== 'undefined')
-    profileDetails.obscurePublicRecords = obscurePublicRecords;
+    const profileDetails = {
+      shortDID,
+      shortHandle,
+      avatarUrl,
+      bannerUrl,
+      displayName,
+      description,
+    };
+    if (typeof obscurePublicRecords !== 'undefined')
+      profileDetails.obscurePublicRecords = obscurePublicRecords;
 
-  resolveHandleCache.prepopulate(shortDID, shortHandle);
-  return profileDetails;
-});
+    resolveHandleCache.prepopulate(shortDID, shortHandle);
+    return profileDetails;
+  }
+);
 
 function detectObscurePublicRecordsFlag(profileRecord) {
   if (profileRecord?.labels?.length) {
-
     for (const label of profileRecord.labels) {
-      if (label?.val === '!no-unauthenticated' &&
-        !label.neg) {
+      if (label?.val === '!no-unauthenticated' && !label.neg) {
         return true;
       }
     }
@@ -119,7 +144,8 @@ function detectObscurePublicRecordsFlagOld(profileRec) {
  * @returns {AccountInfo | Promise<AccountInfo>}
  */
 export function resolveHandleOrDID(handleOrDid) {
-  if (likelyDID(handleOrDid)) return resolveDIDCache(unwrapShortDID(handleOrDid));
+  if (likelyDID(handleOrDid))
+    return resolveDIDCache(unwrapShortDID(handleOrDid));
   const didOrPromise = resolveHandleCache(unwrapShortHandle(handleOrDid));
 
   if (isPromise(didOrPromise)) return didOrPromise.then(resolveDIDCache);

--- a/src/detail-panels/block-panel-generic/block-panel-generic.js
+++ b/src/detail-panels/block-panel-generic/block-panel-generic.js
@@ -7,12 +7,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import { Button, CircularProgress } from '@mui/material';
 // import { useSearchParams } from 'react-router-dom';
 
-import {
-  isPromise,
-  resolveHandleOrDID,
-  useSingleBlocklist,
-  unwrapShortHandle,
-} from '../../api';
+import { isPromise, resolveHandleOrDID } from '../../api';
 // import { SearchHeaderDebounced } from '../history/search-header';
 import { ListView } from './list-view';
 // import { TableView } from './table-view';
@@ -25,27 +20,24 @@ import { localise } from '../../localisation';
  * @this {never}
  * @param {{
  *  className?: string,
- *  useBlocklistQuery: typeof useSingleBlocklist,
+ *  blocklistQuery: import('@tanstack/react-query').UseInfiniteQueryResult<{ blocklist: (BlockedByRecord | { did: string; blocked_date: string })[]; count?: number }>,
  *  account: AccountInfo | { shortHandle: String, loading: true },
  *  header?: React.ReactNode | ((args: { count, blocklist: any[] }) => React.ReactNode)
  * }} _
  */
 export function BlockPanelGeneric({
   className,
-  useBlocklistQuery,
+  blocklistQuery,
   account,
   header,
 }) {
   const { data, fetchNextPage, hasNextPage, isLoading, isFetching } =
-    useBlocklistQuery(unwrapShortHandle(account.shortHandle));
-
-  const blocklistPages = data?.pages;
+    blocklistQuery;
 
   // const [tableView, setTableView] = React.useState(false);
 
-  const blocklist = blocklistPages?.flatMap((page) => {
-    return page.blocklist;
-  }) || [];
+  const blocklistPages = data?.pages || [];
+  const blocklist = blocklistPages.flatMap((page) => page.blocklist);
   const count = blocklistPages?.[0]?.count;
 
   // const [searchParams, setSearchParams] = useSearchParams();

--- a/src/detail-panels/block-panel-generic/list-view.js
+++ b/src/detail-panels/block-panel-generic/list-view.js
@@ -15,36 +15,32 @@ const GROW_BLOCK_SIZE = 29;
 /**
  * @param {{
  *  account: AccountInfo | { shortHandle: string, loading: true };
- *  blocklist: BlockedByRecord[];
- * }} _ 
+ *  blocklist: (BlockedByRecord | { did: string; blocked_date: string })[];
+ * }} _
  */
 export function ListView({ account, blocklist }) {
   const [listSize, setListSize] = useState(INITIAL_SIZE);
   const showSize = Math.min(blocklist.length, listSize);
 
   return (
-    <ul className='block-list'>
-      {
-        blocklist.slice(0, showSize).map((block, index) => {
-          const entry =
-            <ListViewEntry
-              key={index}
-              account={account}
-              {...block} />;
+    <ul className="block-list">
+      {blocklist.slice(0, showSize).map((block, index) => {
+        const entry = (
+          <ListViewEntry key={index} account={account} {...block} />
+        );
 
-          return (
-            index < showSize - 1 ?
-              entry :
-              <Visible
-                key={index}
-                rootMargin='0px 0px 300px 0px'
-                onVisible={handleBottomVisible}
-              >
-                {entry}
-              </Visible>
-          );
-        })
-      }
+        return index < showSize - 1 ? (
+          entry
+        ) : (
+          <Visible
+            key={index}
+            rootMargin="0px 0px 300px 0px"
+            onVisible={handleBottomVisible}
+          >
+            {entry}
+          </Visible>
+        );
+      })}
     </ul>
   );
 
@@ -61,32 +57,42 @@ export function ListView({ account, blocklist }) {
  * @param {{
  *  account: AccountInfo | {shortHandle: string, loading: true};
  *  blocked_date: string;
- *  handle: string;
+ *  handle?: string;
+ *  did?: string;
  *  className?: string;
  * }} _
  */
-function ListViewEntry({ account, blocked_date, handle, className, ...rest }) {
-
+function ListViewEntry({
+  account,
+  blocked_date,
+  handle,
+  did,
+  className,
+  ...rest
+}) {
   const result = (
     <li {...rest} className={'blocking-list-entry ' + (className || '')}>
       <AccountShortEntry
-        className='blocking-account-link'
+        className="blocking-account-link"
         withDisplayName
         accountTooltipPanel={
-          !blocked_date ? undefined :
-            <div className='account-info-panel-blocked-timestamp'>
+          !blocked_date ? undefined : (
+            <div className="account-info-panel-blocked-timestamp">
               {localise('blocked', { uk: 'заблоковано' })}
-              <div className='account-info-panel-blocked-timestamp-full'>
+              <div className="account-info-panel-blocked-timestamp-full">
                 {new Date(blocked_date).toString()}
               </div>
             </div>
+          )
         }
-        account={handle}>
+        account={handle || did}
+      >
         <FormatTimestamp
           timestamp={blocked_date}
           noTooltip
-          className='blocking-date' />
-        </AccountShortEntry>
+          className="blocking-date"
+        />
+      </AccountShortEntry>
     </li>
   );
 

--- a/src/detail-panels/blocked-by/index.js
+++ b/src/detail-panels/blocked-by/index.js
@@ -4,12 +4,16 @@ import { useSingleBlocklist } from '../../api';
 import { BlockPanelGeneric } from '../block-panel-generic';
 import { localise } from '../../localisation';
 
+/** @param {{ account: AccountInfo | { shortHandle: string; loading: true } }} _ */
 export function BlockedByPanel({ account }) {
+  const did = 'shortDID' in account ? account.shortDID : '';
+  const blocklistQuery = useSingleBlocklist(did);
   return (
     <BlockPanelGeneric
-      className='blocked-by-panel'
-      useBlocklistQuery={useSingleBlocklist}
+      className="blocked-by-panel"
+      blocklistQuery={blocklistQuery}
       account={account}
-      header={({ count }) => <>{localise('Blocked by', { uk: 'Блокують' })}</>} />
+      header={({ count }) => <>{localise('Blocked by', { uk: 'Блокують' })}</>}
+    />
   );
 }

--- a/src/detail-panels/blocking/index.js
+++ b/src/detail-panels/blocking/index.js
@@ -4,12 +4,16 @@ import { useBlocklist } from '../../api';
 import { BlockPanelGeneric } from '../block-panel-generic';
 import { localise } from '../../localisation';
 
+/** @param {{ account: AccountInfo | { shortHandle: string; loading: true } }} _ */
 export function BlockingPanel({ account }) {
+  const did = 'shortDID' in account ? account.shortDID : '';
+  const blocklistQuery = useBlocklist(did);
   return (
     <BlockPanelGeneric
-      className='blocking-panel'
-      useBlocklistQuery={useBlocklist}
+      className="blocking-panel"
+      blocklistQuery={blocklistQuery}
       account={account}
-      header={({ count }) => <>{localise('Blocking', { uk: 'Блокує' })}</>} />
+      header={({ count }) => <>{localise('Blocking', { uk: 'Блокує' })}</>}
+    />
   );
 }


### PR DESCRIPTION
As discussed in discord previously, the query for blocklist is [perhaps the biggest problem facing the database](https://discord.com/channels/1309769535888429098/1309769535888429101/1310497760352538655) right now. This completely removes that query from being used in the UI, instead [going directly to a user's own PDS](https://discord.com/channels/1309769535888429098/1310042550429810832/1310230319177404437) to retrieve their list of blocked users.