### PR TITLE
Remove "as of" field from HomeStatsTable

### DIFF
--- a/src/api/dashboard-stats.js
+++ b/src/api/dashboard-stats.js
@@ -44,7 +44,7 @@ async function dashboardStatsApi() {
     blockStatsPromise,
   ]);
 
-  const asof = blockStats['as of'] || null;
+  const asof = blockStats['as of'] || initialData.asof;
 
   /** @type {DashboardStats} */
   const result = {

--- a/src/api/dashboard-stats.js
+++ b/src/api/dashboard-stats.js
@@ -44,7 +44,7 @@ async function dashboardStatsApi() {
     blockStatsPromise,
   ]);
 
-  const asof = 'asof' in blockStats ? blockStats.asof : null;
+  const asof = blockStats['as of'] || null;
 
   /** @type {DashboardStats} */
   const result = {

--- a/src/landing/home-stats/home-stats-table.js
+++ b/src/landing/home-stats/home-stats-table.js
@@ -84,12 +84,6 @@ function getGridRowsAndColumns(stats) {
   const rows = [];
 
   rows.push({ Handle: localise('Stats', {}), title: true });
-  if (stats.asof) {
-    rows.push({
-      Handle: localise('as of', {}),
-      block_count: new Date(stats.asof).toLocaleString(),
-    });
-  }
 
   if (stats.totalUsers) {
     /** @type {ValueWithDisplayName[]} */

--- a/src/landing/home-stats/index.js
+++ b/src/landing/home-stats/index.js
@@ -7,6 +7,8 @@ import { useDashboardStats } from '../../api';
 import { parseNumberWithCommas } from '../../api/core';
 import { HomeStatsTable } from './home-stats-table';
 
+import { localise } from '../../localisation';
+
 /**
  * @typedef {{
  *  className: string | undefined;
@@ -31,7 +33,7 @@ export function HomeStats({ className }) {
 
   const { data: stats, isLoading } = useDashboardStats();
 
-  const asofFormatted = stats?.asof && new Date(stats.asof) + '';
+  const asofFormatted = stats?.asof && localise('As of: ', {}) + new Date(stats.asof);
 
   const activeAccounts = parseNumberWithCommas(
     stats?.totalUsers.active_count?.value

--- a/src/landing/home-stats/index.js
+++ b/src/landing/home-stats/index.js
@@ -7,8 +7,6 @@ import { useDashboardStats } from '../../api';
 import { parseNumberWithCommas } from '../../api/core';
 import { HomeStatsTable } from './home-stats-table';
 
-import { localise } from '../../localisation';
-
 /**
  * @typedef {{
  *  className: string | undefined;
@@ -33,7 +31,7 @@ export function HomeStats({ className }) {
 
   const { data: stats, isLoading } = useDashboardStats();
 
-  const asofFormatted = stats?.asof && localise('As of: ', {}) + new Date(stats.asof);
+  const asofFormatted = stats?.asof && new Date(stats.asof) + '';
 
   const activeAccounts = parseNumberWithCommas(
     stats?.totalUsers.active_count?.value


### PR DESCRIPTION
## Fixes: #102 
- Remove "as of" field in stats detail view
- Maybe make it a greyed out placement somewhere, but NOT in the grid view.

## Changes
- Removes a conditional in HomeStatsTable that would add the "as of" row.
- *Fix:* Updates a return value in the dashboard stats API to use a fallback "as of" date from initialData.

## Preview
This "as of" row will be removed from the HomeStatsTable.
<img width="450" alt="ClearskyApp-Issue-102" src="https://github.com/user-attachments/assets/0ed218c1-0ea2-4977-a170-3757663a835e">

