### PR TITLE
187 make locale string for placement less volatile

### DIFF
--- a/src/detail-panels/account-header/account-header.jsx
+++ b/src/detail-panels/account-header/account-header.jsx
@@ -31,9 +31,9 @@ export function AccountHeader({
   console.log(resolved.data)
   const handleHistoryQuery = useHandleHistory(resolved.data?.shortDID);
   const handleHistory = handleHistoryQuery.data?.handle_history;
-
+ 
   const placementquery = usePlacement(resolved.data?.shortDID) ;
-  const placement = placementquery.data?.placement.toLocaleString() ?? ""; 
+  const placement = placementquery.data?.placement ? placementquery.data?.placement.toLocaleString() : ""; 
 
   const handleShortDIDClick = () => {
     // Copy the shortDID to the clipboard

--- a/src/detail-panels/account-header/account-header.jsx
+++ b/src/detail-panels/account-header/account-header.jsx
@@ -33,7 +33,7 @@ export function AccountHeader({
   const handleHistory = handleHistoryQuery.data?.handle_history;
  
   const placementquery = usePlacement(resolved.data?.shortDID) ;
-  const placement = placementquery.data?.placement ? placementquery.data?.placement.toLocaleString() : ""; 
+  const placement = placementquery.data?.placement?.toLocaleString() ?? ""; 
 
   const handleShortDIDClick = () => {
     // Copy the shortDID to the clipboard


### PR DESCRIPTION
the placement of toLocaleString in the last commit of  

[187-add-placement-to-account-info](https://github.com/seanmunson/ClearskyUI/tree/187-add-placement-to-account-info)

introduced an improperly resolved nullity potential. 

This should resolve it by evaluating the value before trying to cast it to local format