### PR TITLE
Enable typescript's strict mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-router-dom": "^6.28.0"
       },
       "devDependencies": {
+        "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
         "typescript": "^5",
         "vite": "^6.0.1"
@@ -1691,6 +1692,16 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
+      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/react-transition-group": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "ui",
-  "version": "4.7.0",
+  "version": "4.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "4.7.0",
+      "version": "4.9.0",
       "license": "ISC",
       "dependencies": {
-        "@atproto/api": "^0.10.4",
+        "@atproto/api": "^0.13.0",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.14.16",
@@ -46,58 +46,60 @@
       }
     },
     "node_modules/@atproto/api": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.10.4.tgz",
-      "integrity": "sha512-9gwZt4v4pngfD4mgsET9i9Ym0PpMSzftTzqBjCbFpObx15zMkFemYnLUnyT/NEww2u/aRxjAe2TeBnU0dIbbuQ==",
+      "version": "0.13.25",
+      "resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.13.25.tgz",
+      "integrity": "sha512-5tz2NvYO7W9+0PV7x4k4KIAIazQI6Km+q4/+O6VUoNSqHsF3ry9/9mjcZKBoJLdmcVtZdcKSlPUTtxthan6iKw==",
+      "license": "MIT",
       "dependencies": {
-        "@atproto/common-web": "^0.2.3",
-        "@atproto/lexicon": "^0.3.2",
-        "@atproto/syntax": "^0.2.0",
-        "@atproto/xrpc": "^0.4.2",
+        "@atproto/common-web": "^0.3.1",
+        "@atproto/lexicon": "^0.4.4",
+        "@atproto/syntax": "^0.3.1",
+        "@atproto/xrpc": "^0.6.5",
+        "await-lock": "^2.2.2",
         "multiformats": "^9.9.0",
         "tlds": "^1.234.0",
-        "typed-emitter": "^2.1.0",
-        "zod": "^3.21.4"
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@atproto/common-web": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.2.3.tgz",
-      "integrity": "sha512-k9VKGYUqjsRlI3wS31XyCbeb2U7ddS4X/eFgzos2CE5rIbk/uQGyKH+0Jcn1JIwRkvI1BemyNuUVrS8Ok3wiuw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.3.1.tgz",
+      "integrity": "sha512-N7wiTnus5vAr+lT//0y8m/FaHHLJ9LpGuEwkwDAeV3LCiPif4m/FS8x/QOYrx1PdZQwKso95RAPzCGWQBH5j6Q==",
+      "license": "MIT",
       "dependencies": {
         "graphemer": "^1.4.0",
         "multiformats": "^9.9.0",
         "uint8arrays": "3.0.0",
-        "zod": "^3.21.4"
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@atproto/lexicon": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.3.2.tgz",
-      "integrity": "sha512-kmGCkrRwpWIqmn/KO4BZwUf8Nmfndk3XvFC06V0ygCWc42g6+t4QP/6ywNW4PgqfZY0Q5aW4EuDfD7KjAFkFtQ==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.4.4.tgz",
+      "integrity": "sha512-QFEmr3rpj/RoAmfX9ALU/asBG/rsVtQZnw+9nOB1/AuIwoxXd+ZyndR6lVUc2+DL4GEjl6W2yvBru5xbQIZWyA==",
+      "license": "MIT",
       "dependencies": {
-        "@atproto/common-web": "^0.2.3",
-        "@atproto/syntax": "^0.2.0",
+        "@atproto/common-web": "^0.3.1",
+        "@atproto/syntax": "^0.3.1",
         "iso-datestring-validator": "^2.2.2",
         "multiformats": "^9.9.0",
-        "zod": "^3.21.4"
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@atproto/syntax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.2.0.tgz",
-      "integrity": "sha512-K+9jl6mtxC9ytlR7msSiP9jVNqtdxEBSt0kOfsC924lqGwuD8nlUAMi1GSMgAZJGg/Rd+0MKXh789heTdeL3HQ==",
-      "dependencies": {
-        "@atproto/common-web": "^0.2.3"
-      }
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.3.1.tgz",
+      "integrity": "sha512-fzW0Mg1QUOVCWUD3RgEsDt6d1OZ6DdFmbKcDdbzUfh0t4rhtRAC05KbZYmxuMPWDAiJ4BbbQ5dkAc/mNypMXkw==",
+      "license": "MIT"
     },
     "node_modules/@atproto/xrpc": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.4.2.tgz",
-      "integrity": "sha512-x4x2QB4nWmLjIpz2Ue9n/QVbVyJkk6tQMhvmDQaVFF89E3FcVI4rxF4uhzSxaLpbNtyVQBNEEmNHOr5EJLeHVA==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.6.5.tgz",
+      "integrity": "sha512-t6u8iPEVbWge5RhzKZDahSzNDYIAxUtop6Q/X/apAZY1rgreVU0/1sSvvRoRFH19d3UIKjYdLuwFqMi9w8nY3Q==",
+      "license": "MIT",
       "dependencies": {
-        "@atproto/lexicon": "^0.3.2",
-        "zod": "^3.21.4"
+        "@atproto/lexicon": "^0.4.4",
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1805,6 +1807,12 @@
         "when-exit": "^2.1.1"
       }
     },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "license": "MIT"
+    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -2172,7 +2180,8 @@
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "license": "MIT"
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -2261,7 +2270,8 @@
     "node_modules/iso-datestring-validator": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/iso-datestring-validator/-/iso-datestring-validator-2.2.2.tgz",
-      "integrity": "sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA=="
+      "integrity": "sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==",
+      "license": "MIT"
     },
     "node_modules/iso-kv": {
       "version": "3.0.3",
@@ -2470,7 +2480,8 @@
     "node_modules/multiformats": {
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/nanoid": {
       "version": "3.3.8",
@@ -2785,15 +2796,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -2866,12 +2868,6 @@
         "tlds": "bin.js"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "optional": true
-    },
     "node_modules/type-fest": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
@@ -2882,14 +2878,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/typed-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
-      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
-      "optionalDependencies": {
-        "rxjs": "*"
       }
     },
     "node_modules/typescript": {
@@ -2922,6 +2910,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.0.0.tgz",
       "integrity": "sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==",
+      "license": "MIT",
       "dependencies": {
         "multiformats": "^9.4.2"
       }
@@ -3050,9 +3039,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "4.9.0",
+      "version": "4.10.0",
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.13.0",
@@ -21,6 +21,7 @@
         "ag-grid-react": "^31.0.3",
         "fuse.js": "^7.0.0",
         "iso-web": "^1.0.6",
+        "punycode2": "^1.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.28.0"
@@ -2635,6 +2636,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/punycode2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/punycode2/-/punycode2-1.0.1.tgz",
+      "integrity": "sha512-+TXpd9YRW4YUZZPoRHJ3DILtWwootGc2DsgvfHmklQ8It1skINAuqSdqizt5nlTaBmwrYACHkHApCXjc9gHk2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/react": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "singleQuote": true
   },
   "dependencies": {
-    "@atproto/api": "^0.10.4",
+    "@atproto/api": "^0.13.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.14.16",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-router-dom": "^6.28.0"
   },
   "devDependencies": {
+    "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "^5",
     "vite": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ag-grid-react": "^31.0.3",
     "fuse.js": "^7.0.0",
     "iso-web": "^1.0.6",
+    "punycode2": "^1.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.28.0"

--- a/src/api/blocklist.js
+++ b/src/api/blocklist.js
@@ -1,9 +1,6 @@
 // @ts-check
 
-import {
-  fetchClearskyApi,
-  unwrapShortDID,
-} from './core';
+import { fetchClearskyApi, unwrapShortDID } from './core';
 import { usePdsUrl } from './pds';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
@@ -18,6 +15,7 @@ export function useBlocklist(did) {
   return useInfiniteQuery({
     enabled: !!(pdsUrl && fullDid),
     queryKey: ['blocks-from-pds', pdsUrl, fullDid],
+    // @ts-expect-error pdsUrl will be a string because the query will be disabled otherwise
     queryFn: ({ pageParam }) => getBlocksFromPds(pdsUrl, fullDid, pageParam),
     initialPageParam: '',
     getNextPageParam: (lastPage) => lastPage.nextCursor,
@@ -59,6 +57,7 @@ export function useSingleBlocklist(did) {
     enabled: !!fullDid,
     queryKey: ['single-blocklist', fullDid],
     queryFn: ({ pageParam }) =>
+      // @ts-expect-error fullDid will be a string because the query will be disabled otherwise
       blocklistCall(fullDid, 'single-blocklist', pageParam),
     initialPageParam: 1,
     getNextPageParam: (lastPage) => lastPage.nextPage,
@@ -74,6 +73,7 @@ export function useBlocklistCount(did) {
   return useQuery({
     enabled: !!fullDid,
     queryKey: ['blocklist-count', fullDid],
+    // @ts-expect-error fullDid will be a string because the query will be disabled otherwise
     queryFn: () => blocklistCountCall(fullDid, 'blocklist'),
   });
 }
@@ -86,6 +86,7 @@ export function useSingleBlocklistCount(did) {
   return useQuery({
     enabled: !!fullDid,
     queryKey: ['single-blocklist-count', fullDid],
+    // @ts-expect-error fullDid will be a string because the query will be disabled otherwise
     queryFn: () => blocklistCountCall(fullDid, 'single-blocklist'),
   });
 }
@@ -96,7 +97,8 @@ export function useSingleBlocklistCount(did) {
  *  data: Data,
  *  identity: string,
  *  status: boolean
- * }} BlocklistResponse */
+ * }} BlocklistResponse
+ */
 
 /**
  * @typedef {{

--- a/src/api/core.js
+++ b/src/api/core.js
@@ -1,24 +1,23 @@
 // @ts-check
 /// <reference path="../types.d.ts" />
 
-import { BskyAgent } from '@atproto/api';
+import { AtpAgent } from '@atproto/api';
 
 export const oldXrpc = 'https://bsky.social/xrpc';
 export const newXrpc = 'https://bsky.network/xrpc';
 export const publicXrpc = 'https://public.api.bsky.app/xrpc';
 
-export const atClient = new BskyAgent({ service: oldXrpc });
+export const atClient = new AtpAgent({ service: oldXrpc });
 patchBskyAgent(atClient);
 
-export const publicAtClient = new BskyAgent({ service: publicXrpc });
+export const publicAtClient = new AtpAgent({ service: publicXrpc });
 patchBskyAgent(publicAtClient);
 
 /** @param {typeof atClient} atClient */
 export function patchBskyAgent(atClient) {
-  atClient.com.atproto.sync._service.xrpc.baseClient.lex.assertValidXrpcOutput =
-    function () {
-      return true;
-    };
+  atClient.com.atproto.sync._client.lex.assertValidXrpcOutput = function () {
+    return true;
+  };
 }
 
 let baseURL = 'https://api.clearsky.services/';
@@ -47,10 +46,13 @@ export function fetchClearskyApi(apiVer, apiPath) {
   return fetch(apiUrl).then((x) => x.json());
 }
 
+/**
+ * @param {string | undefined | null} shortDID
+ * @returns
+ */
 export function unwrapShortDID(shortDID) {
-  return !shortDID
-    ? undefined
-    : shortDID.indexOf(':') < 0
+  if (!shortDID) return;
+  return shortDID.indexOf(':') < 0
     ? 'did:plc:' + shortDID.toLowerCase()
     : shortDID.toLowerCase();
 }

--- a/src/api/dashboard-stats-base.json
+++ b/src/api/dashboard-stats-base.json
@@ -41,377 +41,93 @@
     "totalUsers": 5399765
   },
   "topLists": {
-    "blocked": {
-      "did:plc:aeuetvb7vac3xay76nkphbks": {
-        "handle": "jordanbpeterson.bsky.social",
-        "count": 17390
-      },
-      "did:plc:s3kgjpyoec2fd7ztruqiaxwx": {
-        "handle": "aify.co",
-        "count": 13646
-      },
-      "did:plc:byet53dwfmr5at7xk56zwmxv": {
-        "handle": "endwokeness.bsky.social",
-        "count": 12078
-      },
-      "did:plc:rjlu6npi554qkz2jcvdt7mc3": {
-        "handle": "shortcovid.bsky.social",
-        "count": 9815
-      },
-      "did:plc:xfqcsi7wuwedeqaa5m7aih44": {
-        "handle": "anonymous.expectus.fyi",
-        "count": 8890
-      },
-      "did:plc:5krm4pb5gecb5uawvgr7uxuu": {
-        "handle": "90sanime.pics",
-        "count": 8542
-      },
-      "did:plc:cmo3ypyyvybcgyi2tg2x4sge": {
-        "handle": "mdbreathe.bsky.social",
-        "count": 8339
-      },
-      "did:plc:k2weqoffrljoi7d45jjhjaqk": {
-        "handle": "thedevil.bsky.social",
-        "count": 7927
-      },
-      "did:plc:wwakmfq74pvducx2pbbdxhlg": {
-        "handle": "catswithaura.bsky.social",
-        "count": 7521
-      },
-      "did:plc:56eikwlvdd4htq727624spkg": {
-        "handle": "9gag.bsky.social",
-        "count": 7369
-      },
-      "did:plc:vzakzcxo3dqgjvlgmqlakcb5": {
-        "handle": "afdberlin.bsky.social",
-        "count": 7184
-      },
-      "did:plc:jfpub26kfrtponcqzi7i7udl": {
-        "handle": "womensart1.bsky.social",
-        "count": 6361
-      },
-      "did:plc:gr3zsqab63cfvv7nao4mrh7v": {
-        "handle": "artificial.bsky.social",
-        "count": 6016
-      },
-      "did:plc:2gwoe546lp565vxmzzy2emsl": {
-        "handle": "ewerickson.bsky.social",
-        "count": 5993
-      },
-      "did:plc:ha5tvry6kkxiujam6kyjgagg": {
-        "handle": "poeticalphotos.bsky.social",
-        "count": 5871
-      },
-      "did:plc:hwbjiajbxxij27fzdxwgp7h7": {
-        "handle": "julianreichelt.bsky.social",
-        "count": 5867
-      },
-      "did:plc:m4wkkbc4k5e46hus7zy3tijd": {
-        "handle": "funnyordie.bsky.social",
-        "count": 5773
-      },
-      "did:plc:uvsztbhnf2gcplblz5hitxc7": {
-        "handle": "culture-crit.bsky.social",
-        "count": 5700
-      },
-      "did:plc:kazwkrel3bvgeqm3wdiydwdf": {
-        "handle": "aisky.bsky.social",
-        "count": 5615
-      },
-      "did:plc:i6r2cszqypv2qkp5wvppkndo": {
-        "handle": "othingstodo.bsky.social",
-        "count": 5601
-      }
-    },
-    "blocked_aid": {
-      "did:plc:2gwoe546lp565vxmzzy2emsl": "bafkreigkyri2ge24a2gjvbyfqhpv72ean3kqdr5im6e3njdgfcosgtaly4",
-      "did:plc:56eikwlvdd4htq727624spkg": "bafkreic2xkbo646nxl44z3zk2zeighlvsgltoqjoolc3ihc26p4sdxityu",
-      "did:plc:5krm4pb5gecb5uawvgr7uxuu": "bafkreie6vz5gykxxdf777yiirarw3eyvycbg46to6dknynbxwqrcsl5mfu",
-      "did:plc:aeuetvb7vac3xay76nkphbks": "bafkreibnus2odyijekzkiarrthjwwjjaxbqor5ueopfsa3ezk3doyd3t2a",
-      "did:plc:byet53dwfmr5at7xk56zwmxv": "bafkreie5wkm74v6kewoeukcla2hdvzfcfsmqvtm5mhnxdvabgjd2fc2jvm",
-      "did:plc:cmo3ypyyvybcgyi2tg2x4sge": "bafkreicvorlfinnmygp5ibd65wjvr6tq526fkaksgsrls7v4bw3caluko4",
-      "did:plc:gr3zsqab63cfvv7nao4mrh7v": "bafkreias26vb2aujzaktxnnzgkqkydf3unkdu4qd6l765fdvqbt5xe6hma",
-      "did:plc:ha5tvry6kkxiujam6kyjgagg": "bafkreigdoleeclxuwukhhqwqsftrofuazhqhvab377v3tyk4jazkvn2ixi",
-      "did:plc:hwbjiajbxxij27fzdxwgp7h7": "bafkreidsd5niiokjiqkrgi3ko444rne6t2qhaeyvyhvz7ahjgyyih3xzie",
-      "did:plc:i6r2cszqypv2qkp5wvppkndo": "bafkreia6amuooyaq4uk5smuyhks6wqdipso4yjsv46fszxq6zuvkzkjhqy",
-      "did:plc:jfpub26kfrtponcqzi7i7udl": "bafkreib35vtob7wsqhye4t3tgkoprye5qeqv4fauedcqomfm3yj6oae52i",
-      "did:plc:k2weqoffrljoi7d45jjhjaqk": "bafkreiamm5zsg4fs5gt3qv6ljam57a45ulb2ova5zk2f7sagr4cvowiroq",
-      "did:plc:kazwkrel3bvgeqm3wdiydwdf": "bafkreieihktyf7lcy3votcdxkvahtzyyroak34uf42zae4i2be76fnupkm",
-      "did:plc:m4wkkbc4k5e46hus7zy3tijd": "bafkreibxjsxyd452tupsqjw252jjnsaqaooyqdhvrdafsu3rhprtcsktfi",
-      "did:plc:rjlu6npi554qkz2jcvdt7mc3": "bafkreia7nn5zcs7eftzihvaqhcqd2wge2s4xyel2rebpvtk7p4sjwwae3y",
-      "did:plc:s3kgjpyoec2fd7ztruqiaxwx": "bafkreigstp5o3tazxxln47estmi3fvq52wvl3ktnn4bldxnw4mueb5wppa",
-      "did:plc:uvsztbhnf2gcplblz5hitxc7": "bafkreieximiueazfy7vqej35sea7477l75tweiipvthjicwqzxz3njy52u",
-      "did:plc:vzakzcxo3dqgjvlgmqlakcb5": "bafkreibcalpe4ceeh27wuu42irlkgb3rm6dcxyk3bqcfe7xnjpxxiqojsy",
-      "did:plc:wwakmfq74pvducx2pbbdxhlg": "bafkreieeqwlz7l4lk6eztvyfnowockjstvksrqsfveb7hk2rv5rkfuihtm",
-      "did:plc:xfqcsi7wuwedeqaa5m7aih44": "bafkreic6auduax3rkmtm6xgaetan5osdm454a4y5wc5ryfcjkg5gnfqhmu"
-    },
-    "blockers": {
-      "did:plc:aaelnwlxvflllswegmearbwo": {
-        "handle": "godemperorof.bsky.social",
-        "count": 538414
-      },
-      "did:plc:e4fsmjcj33khuqi6prspceiy": {
-        "handle": "chiefkeef.bsky.social",
-        "count": 32919
-      },
-      "did:plc:vvzu3m7xgl6nldqjbp25pitj": {
-        "handle": "joshuajoy.bsky.social",
-        "count": 11337
-      },
-      "did:plc:yjxotndhnf4jsldpzh3dbbhe": {
-        "handle": "reishoku.bsky.social",
-        "count": 8618
-      },
-      "did:plc:4plzygasgydhuirdrlflqbjo": {
-        "handle": "benclombardo.bsky.social",
-        "count": 8353
-      },
-      "did:plc:cgxxlxuypmkdqdcpioqny5r6": {
-        "handle": "populuxe.bsky.social",
-        "count": 7787
-      },
-      "did:plc:mauk6khnlclkr5k2hnezgmja": {
-        "handle": "thewrittentevs.bsky.social",
-        "count": 5400
-      },
-      "did:plc:d2c3m3xnz4e3x774bq7w43pc": {
-        "handle": "likeamilkdud.bsky.social",
-        "count": 5251
-      },
-      "did:plc:o6p7fbjv2xyijweh5uexdeun": {
-        "handle": "csam.okconfirmed.com",
-        "count": 4569
-      },
-      "did:plc:6odst3452scxthx7w3v2tiav": {
-        "handle": "fresh-newlook.bsky.social",
-        "count": 4346
-      },
-      "did:plc:axrs65zc6hj3m5axp3fth6pw": {
-        "handle": "sunsetsnow.bsky.social",
-        "count": 4263
-      },
-      "did:plc:mafslxu4vgugbybjzsuqxdqr": {
-        "handle": "pupgamer.bsky.social",
-        "count": 4243
-      },
-      "did:plc:nyykk5p7laar725gdnypopsh": {
-        "handle": "itwont.run",
-        "count": 4160
-      },
-      "did:plc:lsoslz2tnl5rudrd7toaxly3": {
-        "handle": "sunagimochan.bsky.social",
-        "count": 3554
-      },
-      "did:plc:wgiw4zvjhfhhubf6dtocjern": {
-        "handle": "hamandegger.bsky.social",
-        "count": 3462
-      },
-      "did:plc:yq6oqday6xtoqcgigdotnglw": {
-        "handle": "blueotter.bsky.social",
-        "count": 3376
-      },
-      "did:plc:2col443nxnlr3qxmlh53u2oi": {
-        "handle": "palomar.bsky.social",
-        "count": 3321
-      },
-      "did:plc:ptlddkaqekq5xj4icqh3btu3": {
-        "handle": "nanamiasari.bsky.social",
-        "count": 3320
-      },
-      "did:plc:ofca62ov5uoae3j772j5vxkx": {
-        "handle": "elaxor.bsky.social",
-        "count": 3210
-      },
-      "did:plc:nhfzuw3qpspigcbhopyjyoxg": {
-        "handle": "john88.bsky.social",
-        "count": 2987
-      }
-    },
-    "blockers_aid": {
-      "did:plc:2col443nxnlr3qxmlh53u2oi": "",
-      "did:plc:4plzygasgydhuirdrlflqbjo": "bafkreidmvofs6nmkoqadp4vkvh26jzh73bzvf5s2ajvt5ztnkqxneyayvq",
-      "did:plc:6odst3452scxthx7w3v2tiav": "bafkreid4znwozgnn5vz7jhk5wsub73dkwnqf3hu4cs7u5njewqiixugi4q",
-      "did:plc:aaelnwlxvflllswegmearbwo": "bafkreicekc6sdf7i5aibzo6yhmuvykwj43gruxmyc5wsmgkahflswwez6a",
-      "did:plc:axrs65zc6hj3m5axp3fth6pw": "bafkreicqwvuqqhzi6vzexyi7c5arfov4cqr26hkxggameqmd3nkldovud4",
-      "did:plc:cgxxlxuypmkdqdcpioqny5r6": "bafkreiaaaksgtbfk7wvuwrzgyrssvfqm7gzxmilsf6w4jz33eiz6auwyo4",
-      "did:plc:d2c3m3xnz4e3x774bq7w43pc": "bafkreig672aogrqgj6hj3fhilgetxrfty4pf3vv2q25sjzm4uicnvs3wru",
-      "did:plc:e4fsmjcj33khuqi6prspceiy": "bafkreifykraakgmpblk7q574amv23yffetp43fmxubja4vnhu74rob3ida",
-      "did:plc:lsoslz2tnl5rudrd7toaxly3": "bafkreicqe2lokrhlmxi2zvygqeq2wycap6fsfq3ljy5l7n36kxggyzghee",
-      "did:plc:mafslxu4vgugbybjzsuqxdqr": "bafkreicmimmf727toysnirqlrngcr3dtdcqq76dklzdqhsz7gkaz6enpli",
-      "did:plc:mauk6khnlclkr5k2hnezgmja": "bafkreigbmijkhof4qsutjttodry4h33euthlu6xcvezzxlie2aejuhteaq",
-      "did:plc:nhfzuw3qpspigcbhopyjyoxg": "",
-      "did:plc:nyykk5p7laar725gdnypopsh": "bafkreidao55d575zbvdekot3zvtqq63lj4ebdj2ydodjy4n7o4vr3dkstm",
-      "did:plc:o6p7fbjv2xyijweh5uexdeun": "bafkreiepeuh6mz4pc2mzmjyysizxz47zcm454tednxk5ntrmu5miuvjgr4",
-      "did:plc:ofca62ov5uoae3j772j5vxkx": "bafkreiezuxscejajajbivlygsbfmeqkbquwugp7hltxcetcbzyjydhjroe",
-      "did:plc:ptlddkaqekq5xj4icqh3btu3": "bafkreidrkrwvnj5kvnyyhgmbvcqrytwjuxh2kcogfhv7ipnj6qjqpbicdu",
-      "did:plc:vvzu3m7xgl6nldqjbp25pitj": "bafkreifjxjfheaynu5cvf4zxqkw3jhr5urwkqykklq64bggdghhmeddfji",
-      "did:plc:wgiw4zvjhfhhubf6dtocjern": "bafkreibkkfry5co2opt3itgcx3y2dkuqwpy3kzwkmf5b6b7q6i76qutduu",
-      "did:plc:yjxotndhnf4jsldpzh3dbbhe": "bafkreifomfskzqebqe2h7as2m2e3g6tmnmzintulxgw7gdvvdmhesdbq4u",
-      "did:plc:yq6oqday6xtoqcgigdotnglw": "bafkreif7yd74dsurrjboyvrqwmwdbhpqs3w4eku36gmcw2vfqk4vncrnyq"
-    },
-    "blocked24": {
-      "did:plc:srszfyoy7rnvbayspnvo6gzk" : {
-        "handle": "william1ng.bsky.social",
-        "count": 472
-      },
-      "did:plc:lq27lgik3ku2qg6zfxmil5xo" : {
-        "handle": "permabanned.bsky.social",
-        "count": 301
-      },
-      "did:plc:7umvpuxe2vbrc3zrzuquzniu": {
-        "handle": "whstancil.bsky.social",
-        "count": 242
-      },
-      "did:plc:gvgcih7d6m3e2hvyq46igazf": {
-        "handle": "nihilinterit.bsky.social",
-        "count": 222
-      },
-      "did:plc:3j6zhuwhlaq6ce3whn6psuzf": {
-        "handle": "thallus.bsky.social",
-        "count": 202
-      },
-      "did:plc:inbqnvflb7h2yiiaz7csx3wc": {
-        "handle": "terfslayer.bsky.social",
-        "count": 174
-      },
-      "did:plc:aev34tr3qek5p4xpgkqte7ve": {
-        "handle": "saltyserpent.bsky.social",
-        "count": 127
-      },
-      "did:plc:6m3d4kvetsgyuv63fal2nfeh": {
-        "handle": "therealericg765.bsky.social",
-        "count": 126
-      },
-      "did:plc:k5igcriqmplffxazxux36dk3": {
-        "handle": "bargdaffy.bsky.social",
-        "count": 124
-      },
-      "did:plc:kkwgudwujvnik2wwohuxr36q": {
-        "handle": "sarahiscute.bsky.social",
-        "count": 111
-      },
-      "did:plc:qdriunexx3nobe5kpltycouy": {
-        "handle": "rexs1gma.bsky.social",
-        "count": 106
-      },
-      "did:plc:pbeh735amil4zwnwfidbwawx": {
-        "handle": "schierkujaschierk.bsky.social",
-        "count": 101
-      },
-      "did:plc:jq6adp6xpuywzmkkq5xhgsli": {
-        "handle": "lofibaby.bsky.social",
-        "count": 101
-      },
-      "did:plc:izwkrpapa4baoz4cfxkyri3t": {
-        "handle": "navin5u.bsky.social",
-        "count": 100
-      },
-      "did:plc:3w6lqhoiwb4oyxkq4vkezmoh": {
-        "handle": "contexthuman5u.bsky.social",
-        "count": 100
-      },
-      "did:plc:7hdkruwu4o5ctjvgasmoq7kz": {
-        "handle": "200motels.bsky.social",
-        "count": 95
-      },
-      "did:plc:l4yavyh246boe7uzo4cua2ns": {
-        "handle": "nowarbutclasswar.bsky.social",
-        "count": 91
-      },
-      "did:plc:4mbllyfo5h6macrye35rg2dv": {
-        "handle": "sdesk.bsky.social",
-        "count": 90
-      },
-      "did:plc:3le6pwxcgwunzz6o77x2z7ar": {
-        "handle": "meginstarlight.bsky.social",
-        "count": 84
-      },
-      "did:plc:cnjc3bgo6werfibdv7ztbwbs": {
-        "handle": "lukemaskwalker.bsky.social",
-        "count": 82
-      }
-    },
-    "blockers24": {
-      "did:plc:aaelnwlxvflllswegmearbwo": {
-        "handle": "godemperorof.bsky.social",
-        "count": 6419
-      },
-      "did:plc:d7pkd2naqqxa6eutobyokvp5": {
-        "handle": "hatac009.bsky.social",
-        "count": 1080
-      },
-      "did:plc:g2xshwj4o33b5wzxs3xspfxk": {
-        "handle": "whydoilikethis.bsky.social",
-        "count": 539
-      },
-      "did:plc:5gspcix3gh6xlpq7cpud3igc": {
-        "handle": "cynanthrope.bsky.social",
-        "count": 409
-      },
-      "did:plc:nsf5dhzypf4e3j4ujlxsw6mj": {
-        "handle": "jeanbath.bsky.social",
-        "count": 299
-      },
-      "did:plc:ni3wjvylk76d5q7mk665bgac": {
-        "handle": "fierydarkstar.bsky.social",
-        "count": 245
-      },
-      "did:plc:ejn42lyctdwfin3ymjoenebs": {
-        "handle": "joshaustin.tech",
-        "count": 236
-      },
-      "did:plc:nhfzuw3qpspigcbhopyjyoxg": {
-        "handle": "john88.bsky.social",
-        "count": 221
-      },
-      "did:plc:kc6b7l5qnaylgnrkpo4apnms": {
-        "handle": "pyritohedron.bsky.social",
-        "count": 190
-      },
-      "did:plc:3tahovyvo3t2cp5rshxalw33": {
-        "handle": "murxibald.vegantifa.de",
-        "count": 190
-      },
-      "did:plc:afiyi64xi7t2jppwbfwujvrl": {
-        "handle": "shisuiten.bsky.social",
-        "count": 173
-      },
-      "did:plc:mjllre6n522jmm6wfaguifuw": {
-        "handle": "helinon.bsky.social",
-        "count": 160
-      },
-      "did:plc:laox4youuo2r5bw2nxlfkxla": {
-        "handle": "limbischessystem.bsky.social",
-        "count": 149
-      },
-      "did:plc:rcpdouakmhwfitbxf4wlf73g": {
-        "handle": "enyantiomer.bsky.social",
-        "count": 134
-      },
-      "did:plc:aui4nwz642bg4edbkvexogcw": {
-        "handle": "kristianharstad.bsky.social",
-        "count": 114
-      },
-      "did:plc:bsfkrvkgspgv7nx7yyvn6kfy": {
-        "handle": "simomo.bsky.social",
-        "count": 103
-      },
-      "did:plc:vpaoviy4grvnajgaze6642tf": {
-        "handle": "nationalist.bsky.social",
-        "count": 100
-      },
-      "did:plc:j5azar2i2m33clf4gx6s3q5l": {
-        "handle": "lunastarlight123.bsky.social",
-        "count": 99
-      },
-      "did:plc:kyj73ifujf6tnhe7s5wpoam4": {
-        "handle": "666naberius666.bsky.social",
-        "count": 97
-      },
-      "did:plc:6icr4tipspgctwsl24lv5r3y": {
-        "handle": "ponderosa121.bsky.social",
-        "count": 95
-      }
-    }
+    "blocked": [
+      { "did": "did:plc:aeuetvb7vac3xay76nkphbks", "count": 17390 },
+      { "did": "did:plc:s3kgjpyoec2fd7ztruqiaxwx", "count": 13646 },
+      { "did": "did:plc:byet53dwfmr5at7xk56zwmxv", "count": 12078 },
+      { "did": "did:plc:rjlu6npi554qkz2jcvdt7mc3", "count": 9815 },
+      { "did": "did:plc:xfqcsi7wuwedeqaa5m7aih44", "count": 8890 },
+      { "did": "did:plc:5krm4pb5gecb5uawvgr7uxuu", "count": 8542 },
+      { "did": "did:plc:cmo3ypyyvybcgyi2tg2x4sge", "count": 8339 },
+      { "did": "did:plc:k2weqoffrljoi7d45jjhjaqk", "count": 7927 },
+      { "did": "did:plc:wwakmfq74pvducx2pbbdxhlg", "count": 7521 },
+      { "did": "did:plc:56eikwlvdd4htq727624spkg", "count": 7369 },
+      { "did": "did:plc:vzakzcxo3dqgjvlgmqlakcb5", "count": 7184 },
+      { "did": "did:plc:jfpub26kfrtponcqzi7i7udl", "count": 6361 },
+      { "did": "did:plc:gr3zsqab63cfvv7nao4mrh7v", "count": 6016 },
+      { "did": "did:plc:2gwoe546lp565vxmzzy2emsl", "count": 5993 },
+      { "did": "did:plc:ha5tvry6kkxiujam6kyjgagg", "count": 5871 },
+      { "did": "did:plc:hwbjiajbxxij27fzdxwgp7h7", "count": 5867 },
+      { "did": "did:plc:m4wkkbc4k5e46hus7zy3tijd", "count": 5773 },
+      { "did": "did:plc:uvsztbhnf2gcplblz5hitxc7", "count": 5700 },
+      { "did": "did:plc:kazwkrel3bvgeqm3wdiydwdf", "count": 5615 },
+      { "did": "did:plc:i6r2cszqypv2qkp5wvppkndo", "count": 5601 }
+    ],
+    "blockers": [
+      { "did": "did:plc:aaelnwlxvflllswegmearbwo", "count": 538414 },
+      { "did": "did:plc:e4fsmjcj33khuqi6prspceiy", "count": 32919 },
+      { "did": "did:plc:vvzu3m7xgl6nldqjbp25pitj", "count": 11337 },
+      { "did": "did:plc:yjxotndhnf4jsldpzh3dbbhe", "count": 8618 },
+      { "did": "did:plc:4plzygasgydhuirdrlflqbjo", "count": 8353 },
+      { "did": "did:plc:cgxxlxuypmkdqdcpioqny5r6", "count": 7787 },
+      { "did": "did:plc:mauk6khnlclkr5k2hnezgmja", "count": 5400 },
+      { "did": "did:plc:d2c3m3xnz4e3x774bq7w43pc", "count": 5251 },
+      { "did": "did:plc:o6p7fbjv2xyijweh5uexdeun", "count": 4569 },
+      { "did": "did:plc:6odst3452scxthx7w3v2tiav", "count": 4346 },
+      { "did": "did:plc:axrs65zc6hj3m5axp3fth6pw", "count": 4263 },
+      { "did": "did:plc:mafslxu4vgugbybjzsuqxdqr", "count": 4243 },
+      { "did": "did:plc:nyykk5p7laar725gdnypopsh", "count": 4160 },
+      { "did": "did:plc:lsoslz2tnl5rudrd7toaxly3", "count": 3554 },
+      { "did": "did:plc:wgiw4zvjhfhhubf6dtocjern", "count": 3462 },
+      { "did": "did:plc:yq6oqday6xtoqcgigdotnglw", "count": 3376 },
+      { "did": "did:plc:2col443nxnlr3qxmlh53u2oi", "count": 3321 },
+      { "did": "did:plc:ptlddkaqekq5xj4icqh3btu3", "count": 3320 },
+      { "did": "did:plc:ofca62ov5uoae3j772j5vxkx", "count": 3210 },
+      { "did": "did:plc:nhfzuw3qpspigcbhopyjyoxg", "count": 2987 }
+    ],
+    "blocked24": [
+      { "did": "did:plc:srszfyoy7rnvbayspnvo6gzk", "count": 472 },
+      { "did": "did:plc:lq27lgik3ku2qg6zfxmil5xo", "count": 301 },
+      { "did": "did:plc:7umvpuxe2vbrc3zrzuquzniu", "count": 242 },
+      { "did": "did:plc:gvgcih7d6m3e2hvyq46igazf", "count": 222 },
+      { "did": "did:plc:3j6zhuwhlaq6ce3whn6psuzf", "count": 202 },
+      { "did": "did:plc:inbqnvflb7h2yiiaz7csx3wc", "count": 174 },
+      { "did": "did:plc:aev34tr3qek5p4xpgkqte7ve", "count": 127 },
+      { "did": "did:plc:6m3d4kvetsgyuv63fal2nfeh", "count": 126 },
+      { "did": "did:plc:k5igcriqmplffxazxux36dk3", "count": 124 },
+      { "did": "did:plc:kkwgudwujvnik2wwohuxr36q", "count": 111 },
+      { "did": "did:plc:qdriunexx3nobe5kpltycouy", "count": 106 },
+      { "did": "did:plc:pbeh735amil4zwnwfidbwawx", "count": 101 },
+      { "did": "did:plc:jq6adp6xpuywzmkkq5xhgsli", "count": 101 },
+      { "did": "did:plc:izwkrpapa4baoz4cfxkyri3t", "count": 100 },
+      { "did": "did:plc:3w6lqhoiwb4oyxkq4vkezmoh", "count": 100 },
+      { "did": "did:plc:7hdkruwu4o5ctjvgasmoq7kz", "count": 95 },
+      { "did": "did:plc:l4yavyh246boe7uzo4cua2ns", "count": 91 },
+      { "did": "did:plc:4mbllyfo5h6macrye35rg2dv", "count": 90 },
+      { "did": "did:plc:3le6pwxcgwunzz6o77x2z7ar", "count": 84 },
+      { "did": "did:plc:cnjc3bgo6werfibdv7ztbwbs", "count": 82 }
+    ],
+    "blockers24": [
+      { "did": "did:plc:aaelnwlxvflllswegmearbwo", "count": 6419 },
+      { "did": "did:plc:d7pkd2naqqxa6eutobyokvp5", "count": 1080 },
+      { "did": "did:plc:g2xshwj4o33b5wzxs3xspfxk", "count": 539 },
+      { "did": "did:plc:5gspcix3gh6xlpq7cpud3igc", "count": 409 },
+      { "did": "did:plc:nsf5dhzypf4e3j4ujlxsw6mj", "count": 299 },
+      { "did": "did:plc:ni3wjvylk76d5q7mk665bgac", "count": 245 },
+      { "did": "did:plc:ejn42lyctdwfin3ymjoenebs", "count": 236 },
+      { "did": "did:plc:nhfzuw3qpspigcbhopyjyoxg", "count": 221 },
+      { "did": "did:plc:kc6b7l5qnaylgnrkpo4apnms", "count": 190 },
+      { "did": "did:plc:3tahovyvo3t2cp5rshxalw33", "count": 190 },
+      { "did": "did:plc:afiyi64xi7t2jppwbfwujvrl", "count": 173 },
+      { "did": "did:plc:mjllre6n522jmm6wfaguifuw", "count": 160 },
+      { "did": "did:plc:laox4youuo2r5bw2nxlfkxla", "count": 149 },
+      { "did": "did:plc:rcpdouakmhwfitbxf4wlf73g", "count": 134 },
+      { "did": "did:plc:aui4nwz642bg4edbkvexogcw", "count": 114 },
+      { "did": "did:plc:bsfkrvkgspgv7nx7yyvn6kfy", "count": 103 },
+      { "did": "did:plc:vpaoviy4grvnajgaze6642tf", "count": 100 },
+      { "did": "did:plc:j5azar2i2m33clf4gx6s3q5l", "count": 99 },
+      { "did": "did:plc:kyj73ifujf6tnhe7s5wpoam4", "count": 97 },
+      { "did": "did:plc:6icr4tipspgctwsl24lv5r3y", "count": 95 }
+    ]
   }
 }

--- a/src/api/dashboard-stats.js
+++ b/src/api/dashboard-stats.js
@@ -44,13 +44,13 @@ async function dashboardStatsApi() {
     blockStatsPromise,
   ]);
 
-  const asof = blockStats['as of'] || initialData.asof;
+  const asof = 'asof' in blockStats ? blockStats.asof : initialData.asof;
 
-   /** @type {FunFacts} */
-  const funFactsData = 'data' in funFacts ? funFacts.data : null
+  /** @type {FunFacts | null} */
+  const funFactsData = 'data' in funFacts ? funFacts.data : null;
 
-  /** @type {FunnerFacts} */
-  const funnerFactsData = 'data' in funnerFacts ? funnerFacts.data : null
+  /** @type {FunnerFacts | null} */
+  const funnerFactsData = 'data' in funnerFacts ? funnerFacts.data : null;
 
   /** @type {DashboardStats} */
   const result = {
@@ -58,10 +58,10 @@ async function dashboardStatsApi() {
     totalUsers: 'data' in totalUsers ? totalUsers.data : null,
     blockStats: 'data' in blockStats ? blockStats.data : null,
     topLists: {
-      blocked: funFactsData ? funFactsData.blocked: null,
+      blocked: funFactsData ? funFactsData.blocked : null,
       blockers: funFactsData ? funFactsData.blockers : null,
       blocked24: funnerFactsData ? funnerFactsData.blocked24 : null,
-      blockers24: funnerFactsData ? funnerFactsData.blockers24: null
+      blockers24: funnerFactsData ? funnerFactsData.blockers24 : null,
     },
   };
   return result;

--- a/src/api/handle-history.js
+++ b/src/api/handle-history.js
@@ -15,12 +15,13 @@ import { fetchClearskyApi } from './core';
 
 /**
  *
- * @param {string} shortDid
+ * @param {string | undefined} shortDid
  */
 export function useHandleHistory(shortDid) {
   return useQuery({
     enabled: !!shortDid,
     queryKey: ['get-handle-history', shortDid],
+    // @ts-expect-error shortDid will be a string, as query is skipped otherwise
     queryFn: () => getHandleHistoryRaw(shortDid, false),
   });
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -97,11 +97,22 @@ export function shortenHandle(input) {
 const _shortenHandle_Regex = /\.bsky\.social$/;
 
 /**
+ * @overload
+ * @param {string} shortHandle
+ * @return {string}
+ */
+/**
+ * @overload
  * @param {string | undefined} shortHandle
+ * @return {string | undefined}
+ */
+/**
+ * @param {string | undefined} shortHandle
+ * @return {string | undefined}
  */
 export function unwrapShortHandle(shortHandle) {
   shortHandle = cheapNormalizeHandle(shortHandle);
-  return !shortHandle
+  return typeof shortHandle !== 'string'
     ? undefined
     : shortHandle.indexOf('.') < 0
     ? shortHandle.toLowerCase() + '.bsky.social'

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -3,21 +3,40 @@
 
 export { useDashboardStats } from './dashboard-stats';
 export { usePostHistory, usePostByUri } from './post-history';
-export { resolveHandleOrDID, useResolveHandleOrDid } from './resolve-handle-or-did';
+export {
+  resolveHandleOrDID,
+  useResolveHandleOrDid,
+} from './resolve-handle-or-did';
 export { searchHandle } from './search';
 export { useSingleBlocklist, useBlocklist } from './blocklist';
 
 import { unwrapShortDID } from './core';
-export { unwrapShortDID } from "./core"
+export { unwrapShortDID } from './core';
 
+/**
+ *
+ * @param {string} did
+ * @param {string} cid
+ * @returns
+ */
 export function getProfileBlobUrl(did, cid) {
   if (!did || !cid) return undefined;
-  return `https://cdn.bsky.app/img/avatar/plain/${unwrapShortDID(did)}/${cid}@jpeg`;
+  return `https://cdn.bsky.app/img/avatar/plain/${unwrapShortDID(
+    did
+  )}/${cid}@jpeg`;
 }
 
+/**
+ *
+ * @param {string} did
+ * @param {string} cid
+ * @returns
+ */
 export function getFeedBlobUrl(did, cid) {
   if (!did || !cid) return undefined;
-  return `https://cdn.bsky.app/img/feed_thumbnail/plain/${unwrapShortDID(did)}/${cid}@jpeg`;
+  return `https://cdn.bsky.app/img/feed_thumbnail/plain/${unwrapShortDID(
+    did
+  )}/${cid}@jpeg`;
 }
 
 /**
@@ -25,17 +44,23 @@ export function getFeedBlobUrl(did, cid) {
  * @returns {{ did: string; handle: null } | { did: null; handle: string }}
  **/
 export function distinguishDidFromHandle(text) {
+  if (!text) {
+    return { did: null, handle: '' };
+  }
   if (likelyDID(text)) {
     return { did: text, handle: null };
   }
   return { did: null, handle: text };
 }
 
-/** @param {string | null | undefined} text */
+/**
+ * @param {string | null | undefined} text
+ **/
 export function likelyDID(text) {
-  return text && (
-    text.trim().startsWith('did:') ||
-    text.trim().length === 24 && !/[^\sa-z0-9]/i.test(text)
+  return (
+    text &&
+    (text.trim().startsWith('did:') ||
+      (text.trim().length === 24 && !/[^\sa-z0-9]/i.test(text)))
   );
 }
 
@@ -45,63 +70,84 @@ export function likelyDID(text) {
  * @template {string | undefined | null} T
  */
 export function shortenDID(did) {
-  return did && /** @type {T} */(did.replace(_shortenDID_Regex, '').toLowerCase() || undefined);
+  return (
+    did &&
+    /** @type {T} */ (
+      did.replace(_shortenDID_Regex, '').toLowerCase() || undefined
+    )
+  );
 }
 
 const _shortenDID_Regex = /^did\:plc\:/;
 
 /**
- * @param {T} handle
- * @returns {T}
+ * @param {T} input
+ * @returns {T | string}
  * @template {string | undefined | null} T
  */
-export function shortenHandle(handle) {
-  handle = cheapNormalizeHandle(handle);
-  return handle && /** @type {T} */(handle.replace(_shortenHandle_Regex, '').toLowerCase() || undefined);
+export function shortenHandle(input) {
+  let handle = cheapNormalizeHandle(input);
+  return (
+    handle &&
+    /** @type {T} */ (
+      handle.replace(_shortenHandle_Regex, '').toLowerCase() || undefined
+    )
+  );
 }
 const _shortenHandle_Regex = /\.bsky\.social$/;
 
+/**
+ * @param {string | undefined} shortHandle
+ */
 export function unwrapShortHandle(shortHandle) {
   shortHandle = cheapNormalizeHandle(shortHandle);
-  return !shortHandle ? undefined : shortHandle.indexOf('.') < 0 ? shortHandle.toLowerCase() + '.bsky.social' : shortHandle.toLowerCase();
+  return !shortHandle
+    ? undefined
+    : shortHandle.indexOf('.') < 0
+    ? shortHandle.toLowerCase() + '.bsky.social'
+    : shortHandle.toLowerCase();
 }
 
-function cheapNormalizeHandle(handle) {
-  handle = handle && handle.trim().toLowerCase();
+/**
+ * @param {T} input
+ * @returns {T | string}
+ * @template {string | undefined | null} T
+ */
+function cheapNormalizeHandle(input) {
+  if (!input) return input;
+  let handle = input && input.trim().toLowerCase();
 
-  if (handle && handle.charCodeAt(0) === 64)
-    handle = handle.slice(1);
+  if (handle && handle.charCodeAt(0) === 64) handle = handle.slice(1);
 
   const urlprefix = 'https://bsky.app/';
   if (handle && handle.lastIndexOf(urlprefix, 0) === 0) {
     const postURL = breakPostURL(handle);
-    if (postURL && postURL.shortDID)
-      return postURL.shortDID;
+    if (postURL && postURL.shortDID) return postURL.shortDID;
   }
 
   if (handle && handle.lastIndexOf('at:', 0) === 0) {
     const feedUri = breakFeedUri(handle);
-    if (feedUri && feedUri.shortDID)
-      return feedUri.shortDID;
+    if (feedUri && feedUri.shortDID) return feedUri.shortDID;
   }
 
-  return handle || undefined;
+  return handle;
 }
 
 /**
-* @param {string | null | undefined} url
-*/
+ * @param {string | null | undefined} url
+ */
 export function breakPostURL(url) {
   if (!url) return;
   const match = _breakPostURL_Regex.exec(url);
   if (!match) return;
   return { shortDID: match[1], postID: match[2] };
 }
-const _breakPostURL_Regex = /^http[s]?\:\/\/bsky\.app\/profile\/([a-z0-9\.\:]+)\/post\/([a-z0-9]+)$/;
+const _breakPostURL_Regex =
+  /^http[s]?\:\/\/bsky\.app\/profile\/([a-z0-9\.\:]+)\/post\/([a-z0-9]+)$/;
 
 /**
-* @param {string | null | undefined} uri
-*/
+ * @param {string | null | undefined} uri
+ */
 export function breakFeedUri(uri) {
   if (!uri || !uri.startsWith('at://')) return;
   const [did, type, postID] = uri.replace('at://', '').split('/');

--- a/src/api/lists.js
+++ b/src/api/lists.js
@@ -8,7 +8,7 @@ import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 const PAGE_SIZE = 100;
 
 /**
- * @param {string} handleOrDID
+ * @param {string | undefined} handleOrDID
  */
 export function useList(handleOrDID) {
   const profileQuery = useResolveHandleOrDid(handleOrDID);
@@ -16,6 +16,7 @@ export function useList(handleOrDID) {
   return useInfiniteQuery({
     enabled: !!shortHandle,
     queryKey: ['lists', shortHandle],
+    // @ts-expect-error shortHandle won't really be undefined because the query will be disabled
     queryFn: ({ pageParam }) => getList(shortHandle, pageParam),
     initialPageParam: 1,
     getNextPageParam: (lastPage) => lastPage.nextPage,
@@ -23,7 +24,7 @@ export function useList(handleOrDID) {
 }
 
 /**
- * @param {string} handleOrDID
+ * @param {string | undefined} handleOrDID
  */
 export function useListTotal(handleOrDID) {
   const profileQuery = useResolveHandleOrDid(handleOrDID);
@@ -31,6 +32,7 @@ export function useListTotal(handleOrDID) {
   return useQuery({
     enabled: !!shortHandle,
     queryKey: ['list-total', shortHandle],
+    // @ts-expect-error shortHandle won't really be undefined because the query will be disabled
     queryFn: () => getListTotal(shortHandle),
   });
 }

--- a/src/api/pds.js
+++ b/src/api/pds.js
@@ -6,8 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 
 /**
  *
- * @param {string} did
- * @returns {import('@tanstack/react-query').UseQueryResult<PlcRecord>}
+ * @param {string | undefined} did
  */
 export function useDidDocument(did) {
   return useQuery({
@@ -18,10 +17,17 @@ export function useDidDocument(did) {
 }
 
 /**
- * @param {string} fullDid
+ * @param {string | undefined} fullDid
  * @param {AbortSignal} signal
+ * @returns {Promise<PlcRecord>}
  */
 export async function fetchDidDocument(fullDid, signal) {
+  if (!fullDid) {
+    return {
+      alsoKnownAs: [],
+      service: [],
+    };
+  }
   /** @type {Response} */
   let req;
   if (fullDid.startsWith('did:plc:')) {
@@ -40,7 +46,7 @@ export async function fetchDidDocument(fullDid, signal) {
 
 /**
  *
- * @param {string} did
+ * @param {string | undefined} did
  */
 export function usePdsUrl(did) {
   const { status, error, data } = useDidDocument(did);

--- a/src/api/placement.js
+++ b/src/api/placement.js
@@ -6,28 +6,27 @@ import { useResolveHandleOrDid } from './resolve-handle-or-did';
 import { useQuery } from '@tanstack/react-query';
 
 /**
- * @param {string} handleOrDID
- * @returns {{data:{placement:number}}}
+ * @param {string | undefined} handleOrDID
  */
 export function usePlacement(handleOrDID) {
-    const profileQuery = useResolveHandleOrDid(handleOrDID);
-    const shortHandle = profileQuery.data?.shortHandle;
-    
-    return useQuery({
-      enabled: !!shortHandle,
-      queryKey: ['place', shortHandle],
-      queryFn: () =>  getPlacement(shortHandle),
-    });
-  }
+  const profileQuery = useResolveHandleOrDid(handleOrDID);
+  const shortHandle = profileQuery.data?.shortHandle;
+
+  return useQuery({
+    enabled: !!shortHandle,
+    queryKey: ['place', shortHandle],
+    // @ts-expect-error shortHandle will be a string, as the query is skipped otherwise
+    queryFn: () => getPlacement(shortHandle),
+  });
+}
 
 /**
  * @param {string} shortHandle
  */
 async function getPlacement(shortHandle) {
-    const handleURL = 'placement/' + unwrapShortHandle(shortHandle);
-  
-    /** @type {{ data: { count: number; pages: number } }} */
-    const re = await fetchClearskyApi('v1', handleURL);
-    return re.data;
-  }
-  
+  const handleURL = 'placement/' + unwrapShortHandle(shortHandle);
+
+  /** @type {{ data: { placement: number }, identity: string, status: true } | { status: false }} */
+  const re = await fetchClearskyApi('v1', handleURL);
+  return re.status ? re.data : { placement: undefined };
+}

--- a/src/api/resolve-handle-or-did.js
+++ b/src/api/resolve-handle-or-did.js
@@ -51,20 +51,20 @@ export function useResolveHandleOrDid(handleOrDID) {
   return useResolveDidToProfile(did || handleQuery.data);
 }
 
-const queryKeyForHandle = (/** @type {string} */ fullHandle) => [
-  'resolve-handle-to-did',
-  fullHandle,
-];
+const queryKeyForHandle = (
+  /** @type {string | undefined | null} */ fullHandle
+) => ['resolve-handle-to-did', fullHandle];
 /**
  *
  * @param {string | undefined | null} handle
  * @returns the corresponding DID
  */
 function useResolveHandleToDid(handle) {
-  const fullHandle = unwrapShortHandle(handle);
+  const fullHandle = unwrapShortHandle(handle ?? undefined);
   return useQuery({
     enabled: !!fullHandle,
     queryKey: queryKeyForHandle(fullHandle),
+    // @ts-expect-error fullHandle will be a string because the query will be disabled otherwise
     queryFn: () => resolveHandleToDid(fullHandle),
   });
 }

--- a/src/common-components/account-short-entry.jsx
+++ b/src/common-components/account-short-entry.jsx
@@ -7,7 +7,12 @@ import { Tooltip } from '@mui/material';
 import { withStyles } from '@mui/styles';
 import { Link } from 'react-router-dom';
 
-import { distinguishDidFromHandle, likelyDID, unwrapShortHandle, useResolveHandleOrDid } from '../api';
+import {
+  distinguishDidFromHandle,
+  likelyDID,
+  unwrapShortHandle,
+  useResolveHandleOrDid,
+} from '../api';
 import { calcHash } from '../api/core';
 import { FullHandle } from './full-short';
 import { MiniAccountInfo } from './mini-account-info';
@@ -35,16 +40,17 @@ import './account-short-entry.css';
 export function AccountShortEntry({ account, ...rest }) {
   const resolved = useResolveHandleOrDid(account);
 
-  if (resolved.isLoading) return (
-    <LoadingAccount {...rest} handle={account} />
-  );
-  else if (resolved.isError || !resolved.data) return (
-    <ErrorAccount {...rest} error={resolved.error || { message: "not found" }} handle={account} />
-  );
-  else {
+  if (resolved.isLoading) return <LoadingAccount {...rest} handle={account} />;
+  else if (resolved.isError || !resolved.data)
     return (
-      <ResolvedAccount {...rest} account={resolved.data} />
+      <ErrorAccount
+        {...rest}
+        error={resolved.error || { message: 'not found' }}
+        handle={account}
+      />
     );
+  else {
+    return <ResolvedAccount {...rest} account={resolved.data} />;
   }
 }
 
@@ -61,11 +67,11 @@ function ResolvedAccount({
   children,
   customTooltip,
   accountTooltipPanel,
-  accountTooltipBanner
+  accountTooltipBanner,
 }) {
-  const avatarClass = account.avatarUrl ?
-    'account-short-entry-avatar account-short-entry-avatar-image' :
-    'account-short-entry-avatar account-short-entry-at-sign';
+  const avatarClass = account.avatarUrl
+    ? 'account-short-entry-avatar account-short-entry-avatar-image'
+    : 'account-short-entry-avatar account-short-entry-at-sign';
 
   const avatarDelay = getAvatarDelay(account);
 
@@ -74,62 +80,79 @@ function ResolvedAccount({
       <span className={'account-short-entry-handle ' + (handleClassName || '')}>
         <span
           className={avatarClass}
-          style={!account.avatarUrl ? undefined :
-            {
-              backgroundImage: `url(${account.avatarUrl})`,
-              animationDelay: avatarDelay
-            }}>@</span>
+          style={
+            !account.avatarUrl
+              ? undefined
+              : {
+                  backgroundImage: `url(${account.avatarUrl})`,
+                  animationDelay: avatarDelay,
+                }
+          }
+        >
+          @
+        </span>
         <FullHandle shortHandle={account.shortHandle || account.shortDID} />
-        {
-          !withDisplayName || !account.displayName ? undefined :
-            <>
-              {' '}<span className='account-short-entry-display-name'>
-                {account.displayName}
-              </span>
-            </>
-        }
+        {!withDisplayName || !account.displayName ? undefined : (
+          <>
+            {' '}
+            <span className="account-short-entry-display-name">
+              {account.displayName}
+            </span>
+          </>
+        )}
       </span>
       {children}
     </span>
   );
 
-  const linkContent =
-    customTooltip ?
-      <FlushBackgroundTooltip title={customTooltip}>{handleWithContent}</FlushBackgroundTooltip> :
-      accountTooltipPanel || accountTooltipBanner ?
-        (
-          <FlushBackgroundTooltip
-            title={
-              <MiniAccountInfo
-                account={account}
-                children={accountTooltipPanel === true ? undefined : accountTooltipPanel}
-                banner={accountTooltipBanner === true ? undefined : accountTooltipBanner} />
-            }>
-            {handleWithContent}
-          </FlushBackgroundTooltip>
-        ) :
-        handleWithContent;
-  
-  if (link === false) return (
-    <span
-      className={'account-short-entry ' + (className || '')}>
-      {linkContent}
-    </span>
+  const linkContent = customTooltip ? (
+    <FlushBackgroundTooltip title={customTooltip}>
+      {handleWithContent}
+    </FlushBackgroundTooltip>
+  ) : accountTooltipPanel || accountTooltipBanner ? (
+    <FlushBackgroundTooltip
+      title={
+        <MiniAccountInfo
+          account={account}
+          children={
+            accountTooltipPanel === true ? undefined : accountTooltipPanel
+          }
+          banner={
+            accountTooltipBanner === true ? undefined : accountTooltipBanner
+          }
+        />
+      }
+    >
+      {handleWithContent}
+    </FlushBackgroundTooltip>
+  ) : (
+    handleWithContent
   );
+
+  if (link === false)
+    return (
+      <span className={'account-short-entry ' + (className || '')}>
+        {linkContent}
+      </span>
+    );
 
   return (
     <Link
       to={link || `/${unwrapShortHandle(account.shortHandle)}/history`}
-      className={'account-short-entry ' + (className || '')}>
+      className={'account-short-entry ' + (className || '')}
+    >
       {linkContent}
     </Link>
   );
-
 }
 
+/** @type {Record<string, string>} */
 const avatarDelays = {};
 const delayRandomBase = Math.random() * 400;
 
+/**
+ * @param {AccountInfo} account
+ */
 function getAvatarDelay(account) {
   const avatarUrl = account?.avatarUrl;
   if (!avatarUrl) return undefined;
@@ -139,7 +162,7 @@ function getAvatarDelay(account) {
   const hash = calcHash(avatarUrl) / delayRandomBase + delayRandomBase;
   const rnd = Math.abs(hash) - Math.floor(Math.abs(hash));
   delay = (rnd * 40).toFixed(3) + 's';
-  avatarDelays[avatarUrl] = delay; 
+  avatarDelays[avatarUrl] = delay;
   return delay;
 }
 
@@ -153,14 +176,20 @@ function ErrorAccount({
   contentClassName,
   handleClassName,
   link,
-  children
+  children,
 }) {
   const at = likelyDID(handle) ? '\u24d3' : '@';
   const content = (
-    <span className={'account-short-entry-content account-short-entry-error ' + (contentClassName || '')}>
+    <span
+      className={
+        'account-short-entry-content account-short-entry-error ' +
+        (contentClassName || '')
+      }
+    >
       <span className={'account-short-entry-handle ' + (handleClassName || '')}>
-        <span
-          className='account-short-entry-avatar account-short-entry-at-sign'>{at}</span>
+        <span className="account-short-entry-avatar account-short-entry-at-sign">
+          {at}
+        </span>
         <FullHandle shortHandle={handle} />
       </span>
       {children}
@@ -170,16 +199,18 @@ function ErrorAccount({
   const removedAccount =
     /not found/i.test(error.message || '') ||
     /resolve handle/i.test(error.message || '');
-  if (removedAccount) return (
-    <span className={'account-short-entry ' + (className || '')}>
-      {content}
-    </span>
-  );
+  if (removedAccount)
+    return (
+      <span className={'account-short-entry ' + (className || '')}>
+        {content}
+      </span>
+    );
 
   return (
     <Link
       to={link || `/${unwrapShortHandle(handle)}/history`}
-      className={'account-short-entry ' + (className || '')}>
+      className={'account-short-entry ' + (className || '')}
+    >
       {content}
     </Link>
   );
@@ -194,17 +225,26 @@ function LoadingAccount({
   contentClassName,
   handleClassName,
   link,
-  children
+  children,
 }) {
   const at = likelyDID(handle) ? '\u24d3' : '@';
   return (
     <Link
       to={link || `/${unwrapShortHandle(handle)}/history`}
-      className={'account-short-entry ' + (className || '')}>
-      <span className={'account-short-entry-content account-short-entry-loading ' + (contentClassName || '')}>
-        <span className={'account-short-entry-handle ' + (handleClassName || '')}>
-          <span
-            className='account-short-entry-avatar account-short-entry-at-sign'>{at}</span>
+      className={'account-short-entry ' + (className || '')}
+    >
+      <span
+        className={
+          'account-short-entry-content account-short-entry-loading ' +
+          (contentClassName || '')
+        }
+      >
+        <span
+          className={'account-short-entry-handle ' + (handleClassName || '')}
+        >
+          <span className="account-short-entry-avatar account-short-entry-at-sign">
+            {at}
+          </span>
           <FullHandle shortHandle={handle} />
         </span>
         {children}
@@ -216,6 +256,6 @@ function LoadingAccount({
 const FlushBackgroundTooltip = withStyles({
   tooltip: {
     padding: '0',
-    overflow: 'hidden'
-  }
+    overflow: 'hidden',
+  },
 })(Tooltip);

--- a/src/common-components/format-timestamp.jsx
+++ b/src/common-components/format-timestamp.jsx
@@ -27,7 +27,9 @@ export function FormatTimestamp({
   const date = new Date(timestamp);
   const now = Date.now();
 
+  /** @type {string} */
   let dateStr;
+  /** @type {number} */
   let updateDelay;
 
   const dateTime = date.getTime();

--- a/src/common-components/full-short.jsx
+++ b/src/common-components/full-short.jsx
@@ -27,7 +27,7 @@ export function FullHandle({ shortHandle, ...rest }) {
       <span {...rest}>
         {shortHandle}
         <span className="handle-std-suffix">
-          {fullHandle.slice(shortHandle.length)}
+          {fullHandle ? fullHandle.slice(shortHandle.length) : shortHandle}
         </span>
       </span>
     );

--- a/src/common-components/full-short.jsx
+++ b/src/common-components/full-short.jsx
@@ -2,7 +2,12 @@
 // <reference path="../types.d.ts" />
 
 import React from 'react';
-import { likelyDID, shortenHandle, unwrapShortDID, unwrapShortHandle } from '../api';
+import {
+  likelyDID,
+  shortenHandle,
+  unwrapShortDID,
+  unwrapShortHandle,
+} from '../api';
 
 /**
  * @param {{
@@ -12,15 +17,20 @@ import { likelyDID, shortenHandle, unwrapShortDID, unwrapShortHandle } from '../
  */
 export function FullHandle({ shortHandle, ...rest }) {
   if (!shortHandle) return undefined;
-  if (likelyDID(shortHandle)) return <FullDID shortDID={shortHandle} {...rest} />;
+  if (likelyDID(shortHandle))
+    return <FullDID shortDID={shortHandle} {...rest} />;
   const fullHandle = unwrapShortHandle(shortHandle);
   shortHandle = shortenHandle(shortHandle);
   if (shortHandle === fullHandle) return <span {...rest}>{shortHandle}</span>;
-  else return (
-    <span {...rest}>
-      {shortHandle}
-      <span className='handle-std-suffix'>{fullHandle.slice(shortHandle.length)}</span>
-    </span>);
+  else
+    return (
+      <span {...rest}>
+        {shortHandle}
+        <span className="handle-std-suffix">
+          {fullHandle.slice(shortHandle.length)}
+        </span>
+      </span>
+    );
 }
 
 /**
@@ -30,13 +40,16 @@ export function FullHandle({ shortHandle, ...rest }) {
  * }} _
  */
 export function FullDID({ shortDID, ...rest }) {
-  if (!shortDID) return undefined;
   const fullDID = unwrapShortDID(shortDID);
+  if (!shortDID || !fullDID) return undefined;
   if (shortDID === fullDID) return <span {...rest}>{fullDID}</span>;
-  else return (
-    <span {...rest}>
-      <span className='did-std-prefix'>{fullDID.slice(0, -shortDID.length)}</span>
-      {shortDID}
-    </span>
-  );
+  else
+    return (
+      <span {...rest}>
+        <span className="did-std-prefix">
+          {fullDID.slice(0, -shortDID.length)}
+        </span>
+        {shortDID}
+      </span>
+    );
 }

--- a/src/detail-panels/account-header/account-extra-info.jsx
+++ b/src/detail-panels/account-header/account-extra-info.jsx
@@ -25,27 +25,28 @@ export function AccountExtraInfo({ className, ...rest }) {
   const handleHistory = handleHistoryQuery.data?.handle_history;
   return (
     <div className={'account-extra-info ' + (className || '')} {...rest}>
-      <div className='bio-section'>
-        {
-          !account?.description ? undefined :
-            <MultilineFormatted text={account?.description} />
-        }
+      <div className="bio-section">
+        {!account?.description ? undefined : (
+          <MultilineFormatted text={account?.description} />
+        )}
       </div>
-      <div className='did-section'>
-        <DidWithCopyButton shortDID={account?.shortDID} handleHistory={handleHistory} />
+      <div className="did-section">
+        <DidWithCopyButton
+          shortDID={account?.shortDID}
+          handleHistory={handleHistory}
+        />
       </div>
-      <div className='handle-history-section'>
-        {
-          !handleHistory ? undefined :
-            <>
-              <span className='handle-history-title'>
-                {
-                  localise('registration and history:', { uk: 'реєстрація та важливі події:'})
-                }
-              </span>
-              <HandleHistory handleHistory={handleHistory} />
-            </>
-        }
+      <div className="handle-history-section">
+        {!handleHistory ? undefined : (
+          <>
+            <span className="handle-history-title">
+              {localise('registration and history:', {
+                uk: 'реєстрація та важливі події:',
+              })}
+            </span>
+            <HandleHistory handleHistory={handleHistory} />
+          </>
+        )}
       </div>
     </div>
   );
@@ -53,39 +54,40 @@ export function AccountExtraInfo({ className, ...rest }) {
 
 /**
  * @param {{
- *  shortDID: string,
+ *  shortDID: string | undefined,
  *  handleHistory?: import('../../api/handle-history').HandleHistoryResponse['handle_history'],
  * }} _
  */
 function DidWithCopyButton({ shortDID, handleHistory }) {
   const [isCopied, setIsCopied] = React.useState(false);
 
-  const currentPds = handleHistory?.map(entry => entry[2]).filter(Boolean)[0];
+  const currentPds = handleHistory?.map((entry) => entry[2]).filter(Boolean)[0];
 
   return (
     <>
       <FullDID shortDID={shortDID} />
-      {isCopied ?
-        <div className='copied-to-clipboard'>Copied to Clipboard</div> :
-        <Button className='copy-did' onClick={() => handleCopyDid(shortDID)}>
+      {isCopied ? (
+        <div className="copied-to-clipboard">Copied to Clipboard</div>
+      ) : (
+        <Button className="copy-did" onClick={() => handleCopyDid(shortDID)}>
           <ContentCopy />
         </Button>
-      }
-      {
-        !currentPds ? undefined :
-        <div className='current-pds-line'>
-            <PDSName pds={currentPds} />
+      )}
+      {!currentPds ? undefined : (
+        <div className="current-pds-line">
+          <PDSName pds={currentPds} />
         </div>
-      }
+      )}
     </>
   );
 
   /**
-   * @param {string} shortDID 
+   * @param {string | undefined} shortDID
    */
   function handleCopyDid(shortDID) {
     // Copy the shortDID to the clipboard
     const modifiedShortDID = unwrapShortDID(shortDID);
+    if (!modifiedShortDID) return;
     const textField = document.createElement('textarea');
     textField.innerText = modifiedShortDID;
     document.body.appendChild(textField);
@@ -103,7 +105,9 @@ function DidWithCopyButton({ shortDID, handleHistory }) {
   }
 }
 
-
+/**
+ * @param {{ text: string, lineClassName?: string }} _
+ */
 function MultilineFormatted({ text, lineClassName = 'text-multi-line' }) {
   if (!text) return undefined;
   const textWithSpaces = text.replace(/  /g, ' \u00a0');
@@ -115,35 +119,71 @@ function MultilineFormatted({ text, lineClassName = 'text-multi-line' }) {
 
   for (const ln of lines) {
     if (!ln) {
-      lineElements.push(<div key={lineElements.length} style={{ height: '0.5em' }}></div>);
+      lineElements.push(
+        <div key={lineElements.length} style={{ height: '0.5em' }}></div>
+      );
     } else {
       const parts = ln.split(urlRegex).map((part, index) => {
         if (urlRegex.test(part)) {
-          return <a key={index} href={part} target="_blank" rel="noopener noreferrer">{part}</a>;
+          return (
+            <a
+              key={index}
+              href={part}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {part}
+            </a>
+          );
         } else if (atRegex.test(part)) {
           return part.split(atRegex).map((subPart, subIndex) => {
             if (atRegex.test(`@${subPart}`)) {
-              return <a key={subIndex} href={`https://clearsky.app/${subPart}`} rel="noopener noreferrer">@{subPart}</a>;
+              return (
+                <a
+                  key={subIndex}
+                  href={`https://clearsky.app/${subPart}`}
+                  rel="noopener noreferrer"
+                >
+                  @{subPart}
+                </a>
+              );
             }
             return subPart;
           });
         } else if (emailRegex.test(part)) {
           return part.split(emailRegex).map((subPart, subIndex) => {
             if (emailRegex.test(subPart)) {
-              return <a key={subIndex} href={`mailto:${subPart}`} rel="noopener noreferrer">{subPart}</a>;
+              return (
+                <a
+                  key={subIndex}
+                  href={`mailto:${subPart}`}
+                  rel="noopener noreferrer"
+                >
+                  {subPart}
+                </a>
+              );
             }
             return subPart;
           });
         }
         return part;
       });
-      lineElements.push(<Line key={lineElements.length} text={parts} className={lineClassName} />);
+      lineElements.push(
+        <Line
+          key={lineElements.length}
+          text={parts}
+          className={lineClassName}
+        />
+      );
     }
   }
 
   return lineElements;
 }
 
+/**
+ * @param {{ text: React.ReactNode, className: string }} _
+ */
 function Line({ text, className }) {
-  return <div className={className}>{text}</div>
+  return <div className={className}>{text}</div>;
 }

--- a/src/detail-panels/account-header/account-header.jsx
+++ b/src/detail-panels/account-header/account-header.jsx
@@ -12,32 +12,32 @@ import { localise } from '../../localisation';
 import { Button } from '@mui/material';
 import { useAccountResolver } from '../account-resolver';
 import { useHandleHistory } from '../../api/handle-history';
-import {usePlacement} from '../../api/placement';
+import { usePlacement } from '../../api/placement';
 
 /**
  * @param {{
  *  className?: string,
  *  onInfoClick?: () => void,
  *  onCloseClick?: () => void
- * }} _ 
+ * }} _
  */
-export function AccountHeader({
-  className,
-  onInfoClick,
-  onCloseClick }) {
+export function AccountHeader({ className, onInfoClick, onCloseClick }) {
   const [isCopied, setIsCopied] = useState(false);
-  const [handleHistoryExpanded, setHandleHistoryExpanded] = useState(false);
+  // const [handleHistoryExpanded, setHandleHistoryExpanded] = useState(false);
   const resolved = useAccountResolver();
-  console.log(resolved.data)
+  console.log(resolved.data);
   const handleHistoryQuery = useHandleHistory(resolved.data?.shortDID);
   const handleHistory = handleHistoryQuery.data?.handle_history;
- 
-  const placementquery = usePlacement(resolved.data?.shortDID) ;
-  const placement = placementquery.data?.placement?.toLocaleString() ?? ""; 
+
+  const placementquery = usePlacement(resolved.data?.shortDID);
+  const placement = placementquery.data?.placement?.toLocaleString() ?? '';
+
+  const firstHandleChangeTimestamp =
+    handleHistory?.length && handleHistory[handleHistory.length - 1][1];
 
   const handleShortDIDClick = () => {
     // Copy the shortDID to the clipboard
-    const modifiedShortDID = unwrapShortDID(resolved.data?.shortDID);
+    const modifiedShortDID = unwrapShortDID(resolved.data?.shortDID) || '';
     const textField = document.createElement('textarea');
     textField.innerText = modifiedShortDID;
     document.body.appendChild(textField);
@@ -52,65 +52,91 @@ export function AccountHeader({
     setTimeout(() => {
       setIsCopied(false);
     }, 3000);
-  }; 
+  };
+
   return (
     <div className={className}>
       <h1 style={{ margin: 0 }}>
-        {
-          typeof onCloseClick !== 'function' ? undefined :
-            <button
-              title={localise('Back to homepage', { uk: 'Повернутися до головної сторінки' })}
-              className='account-close-button'
-              onClick={onCloseClick}>&lsaquo;</button>
-        }
+        {typeof onCloseClick !== 'function' ? undefined : (
+          <button
+            title={localise('Back to homepage', {
+              uk: 'Повернутися до головної сторінки',
+            })}
+            className="account-close-button"
+            onClick={onCloseClick}
+          >
+            &lsaquo;
+          </button>
+        )}
 
-        <div className='account-banner' style={{
-          backgroundImage: resolved.data?.bannerUrl ? `url(${resolved.data.bannerUrl})` : 'transparent'
-        }}>
-        </div>
+        <div
+          className="account-banner"
+          style={{
+            backgroundImage: resolved.data?.bannerUrl
+              ? `url(${resolved.data.bannerUrl})`
+              : 'transparent',
+          }}
+        ></div>
 
-        {
-          resolved.isSuccess && !resolved.data
-            ? <span>Account not found</span> :
-        <span className='account-avatar-and-displayName-line'>
-          <span className='account-banner-overlay'></span>
-          <span className='account-avatar' style={{
-            backgroundImage: resolved.data?.avatarUrl ? `url(${resolved.data?.avatarUrl})` : 'transparent'
-          }}></span>
-          <span className='account-displayName'>
-            {
-              resolved.data?.displayName ||
-              <span style={{ opacity: '0.5' }}><FullHandle shortHandle={resolved.data?.shortHandle} /></span>
-            }
-          </span><span className='account-handle'>
-          {
-            !resolved.data?.displayName ?  <>
-                <span className='account-handle-at-empty'> </span>
-                                
-                </>  
-              :
-                <>
-                <span className='account-handle-at'>@</span>
-                <a href={`https://bsky.app/profile/${unwrapShortHandle(resolved.data?.shortHandle)}`} target="_blank">
+        {resolved.isSuccess && !resolved.data ? (
+          <span>Account not found</span>
+        ) : (
+          <span className="account-avatar-and-displayName-line">
+            <span className="account-banner-overlay"></span>
+            <span
+              className="account-avatar"
+              style={{
+                backgroundImage: resolved.data?.avatarUrl
+                  ? `url(${resolved.data?.avatarUrl})`
+                  : 'transparent',
+              }}
+            ></span>
+            <span className="account-displayName">
+              {resolved.data?.displayName || (
+                <span style={{ opacity: '0.5' }}>
                   <FullHandle shortHandle={resolved.data?.shortHandle} />
-                </a>
-                </> 
-          }
-          <span className='account-place-number'>{placement}</span>
-           </span>
-          <Button className='history-toggle' variant='text' onClick={onInfoClick}>
-            {
-              handleHistory?.length > 0 && handleHistory[handleHistory.length - 1][1]
-                ? <FormatTimestamp timestamp={handleHistory[handleHistory.length - 1][1]} noTooltip />
-                : 'Unknown Date'
-            }
-            <span className='info-icon'></span>
-          </Button>
-        </span>
-        }
+                </span>
+              )}
+            </span>
+            <span className="account-handle">
+              {!resolved.data?.displayName ? (
+                <>
+                  <span className="account-handle-at-empty"> </span>
+                </>
+              ) : (
+                <>
+                  <span className="account-handle-at">@</span>
+                  <a
+                    href={`https://bsky.app/profile/${unwrapShortHandle(
+                      resolved.data?.shortHandle
+                    )}`}
+                    target="_blank"
+                  >
+                    <FullHandle shortHandle={resolved.data?.shortHandle} />
+                  </a>
+                </>
+              )}
+              <span className="account-place-number">{placement}</span>
+            </span>
+            <Button
+              className="history-toggle"
+              variant="text"
+              onClick={onInfoClick}
+            >
+              {firstHandleChangeTimestamp ? (
+                <FormatTimestamp
+                  timestamp={firstHandleChangeTimestamp}
+                  noTooltip
+                />
+              ) : (
+                'Unknown Date'
+              )}
+              <span className="info-icon"></span>
+            </Button>
+          </span>
+        )}
       </h1>
-      <div>
-      </div>
+      <div></div>
     </div>
   );
 }
@@ -127,7 +153,8 @@ function HandleHistory({ handleHistory }) {
     <div>
       {handleHistory.map(([handle, date], index) => (
         <div key={index}>
-          <FullHandle shortHandle={handle} />{' '}<FormatTimestamp timestamp={date} noTooltip />
+          <FullHandle shortHandle={handle} />{' '}
+          <FormatTimestamp timestamp={date} noTooltip />
         </div>
       ))}
     </div>

--- a/src/detail-panels/block-panel-generic/block-panel-generic.jsx
+++ b/src/detail-panels/block-panel-generic/block-panel-generic.jsx
@@ -23,7 +23,7 @@ import { localise } from '../../localisation';
  *  className?: string,
  *  blocklistQuery: import('@tanstack/react-query').UseInfiniteQueryResult<InfBlockData>,
  *  totalQuery: import('@tanstack/react-query').UseQueryResult<{ count: number }>,
- *  header?: React.ReactNode | ((args: { count, blocklist: any[] }) => React.ReactNode)
+ *  header?: React.ReactNode | ((args: { count: number, blocklist: any[] }) => React.ReactNode)
  * }} _
  */
 export function BlockPanelGeneric({

--- a/src/detail-panels/block-panel-generic/list-view.jsx
+++ b/src/detail-panels/block-panel-generic/list-view.jsx
@@ -1,5 +1,4 @@
 // @ts-check
-/// <reference path="../../types.d.ts" />
 import { FormatTimestamp } from '../../common-components/format-timestamp';
 import { Visible } from '../../common-components/visible';
 import { useState } from 'react';
@@ -56,6 +55,9 @@ export function ListView({ blocklist }) {
  * }} _
  */
 function ListViewEntry({ blocked_date, handle, did, className, ...rest }) {
+  const account = handle || did;
+  if (!account) return null;
+
   const result = (
     <li {...rest} className={'blocking-list-entry ' + (className || '')}>
       <AccountShortEntry
@@ -71,7 +73,7 @@ function ListViewEntry({ blocked_date, handle, did, className, ...rest }) {
             </div>
           )
         }
-        account={handle || did}
+        account={account}
       >
         <FormatTimestamp
           timestamp={blocked_date}

--- a/src/detail-panels/block-panel-generic/table-view.jsx
+++ b/src/detail-panels/block-panel-generic/table-view.jsx
@@ -1,6 +1,5 @@
 // @ts-check
 
-import React from 'react';
 import { AgGridReact } from '../../common-components/ag-grid';
 
 import { AccountShortEntry } from '../../common-components/account-short-entry';
@@ -35,6 +34,9 @@ export function TableView({ account, blocklist }) {
   );
 }
 
+/**
+ * @param {{ value: string }} _
+ */
 export function HandleCellRenderer({ value }) {
   return <AccountShortEntry account={value} />;
 }

--- a/src/detail-panels/history/history-panel.jsx
+++ b/src/detail-panels/history/history-panel.jsx
@@ -16,83 +16,70 @@ export default function HistoryPanel() {
   const account = accountQuery.data;
   const history = usePostHistory(account?.shortDID);
 
+  const [searchParams] = useSearchParams();
+  const searchText = searchParams.get('q') || '';
+
   return (
-    <SearchParamsHelper>
-      {({ searchParams, setSearchParams }) => {
-        const searchText = searchParams.get('q') || '';
-
-        return (
-          <>
-            <SearchHeaderDebounced
-              label={localise('Search history', { uk: 'Шукати в історії' })}
-              setQ
+    <>
+      <SearchHeaderDebounced
+        label={localise('Search history', { uk: 'Шукати в історії' })}
+        setQ
+      />
+      {account?.obscurePublicRecords && (
+        <div className="obscure-public-records-overlay">
+          <div className="obscure-public-records-overlay-content">
+            <AccountShortEntry
+              account={account?.shortDID}
+              withDisplayName
+              link={false}
             />
-            {account?.obscurePublicRecords && (
-              <div className="obscure-public-records-overlay">
-                <div className="obscure-public-records-overlay-content">
-                  <AccountShortEntry
-                    account={account?.shortDID}
-                    withDisplayName
-                    link={false}
-                  />
-                  <div className="obscure-public-records-caption">
-                    {localise(
-                      'has requested to obscure their records from unauthenticated users',
-                      {
-                        uk: 'просить приховати свої повідомлення від неавтентифікованих користувачів',
-                      }
-                    )}
-                    <Tooltip title="To enable this for your profile you can do it in the bsky app via: Settings > Privacy and Security > Logged-out visibility">
-                      <IconButton>
-                        <InfoIcon />
-                      </IconButton>
-                    </Tooltip>
-                  </div>
-                  <Button
-                    variant="outlined"
-                    target="_blank"
-                    href={`https://bsky.app/profile/${unwrapShortHandle(
-                      account?.shortHandle
-                    )}`}
-                  >
-                    {localise('Authenticate', {
-                      uk: 'Автентифікація',
-                    })}
-                  </Button>
-                </div>
-              </div>
-            )}
-            <div
-              className={
-                account?.obscurePublicRecords
-                  ? 'history-panel-container history-panel-container-obscurePublicRecords'
-                  : 'history-panel-container'
-              }
-              style={
+            <div className="obscure-public-records-caption">
+              {localise(
+                'has requested to obscure their records from unauthenticated users',
                 {
-                  // background: 'tomato',
-                  // backgroundColor: '#fffcf5',
-                  // backgroundImage: 'linear-gradient(to bottom, white, transparent 2em)',
+                  uk: 'просить приховати свої повідомлення від неавтентифікованих користувачів',
                 }
-              }
-            >
-              {history.isLoading ? (
-                <HistoryLoading />
-              ) : (
-                <HistoryScrollableList
-                  history={history}
-                  searchText={searchText}
-                />
               )}
+              <Tooltip title="To enable this for your profile you can do it in the bsky app via: Settings > Privacy and Security > Logged-out visibility">
+                <IconButton>
+                  <InfoIcon />
+                </IconButton>
+              </Tooltip>
             </div>
-          </>
-        );
-      }}
-    </SearchParamsHelper>
+            <Button
+              variant="outlined"
+              target="_blank"
+              href={`https://bsky.app/profile/${unwrapShortHandle(
+                account?.shortHandle
+              )}`}
+            >
+              {localise('Authenticate', {
+                uk: 'Автентифікація',
+              })}
+            </Button>
+          </div>
+        </div>
+      )}
+      <div
+        className={
+          account?.obscurePublicRecords
+            ? 'history-panel-container history-panel-container-obscurePublicRecords'
+            : 'history-panel-container'
+        }
+        style={
+          {
+            // background: 'tomato',
+            // backgroundColor: '#fffcf5',
+            // backgroundImage: 'linear-gradient(to bottom, white, transparent 2em)',
+          }
+        }
+      >
+        {history.isLoading ? (
+          <HistoryLoading />
+        ) : (
+          <HistoryScrollableList history={history} searchText={searchText} />
+        )}
+      </div>
+    </>
   );
-}
-
-function SearchParamsHelper({ children }) {
-  const [searchParams, setSearchParams] = useSearchParams();
-  return children({ searchParams, setSearchParams });
 }

--- a/src/detail-panels/history/history-scrollable-list.jsx
+++ b/src/detail-panels/history/history-scrollable-list.jsx
@@ -11,6 +11,7 @@ import { localise } from '../../localisation';
 
 const BLOCK_ADD_INFINITE_SCROLLING = 15;
 
+/** @type {import('./search/cached-search').SearchCacheEntry[]} */
 const globalSearchCache = [];
 
 /**
@@ -83,6 +84,9 @@ export function HistoryScrollableList({ searchText, history }) {
   );
 }
 
+/**
+ * @param {{ historySize: number }} _
+ */
 function CompleteHistoryFooter({ historySize }) {
   return (
     historySize +
@@ -90,6 +94,9 @@ function CompleteHistoryFooter({ historySize }) {
   );
 }
 
+/**
+ * @param {{ historySize: number }} _
+ */
 function LoadingHistoryFooter({ historySize }) {
   return (
     historySize +
@@ -99,6 +106,9 @@ function LoadingHistoryFooter({ historySize }) {
   );
 }
 
+/**
+ * @param {{ historySize: number, onClick(): void }} _
+ */
 function LoadMoreHistoryFooter({ historySize, onClick }) {
   return (
     <span onClick={onClick}>

--- a/src/detail-panels/history/post/post-content-text.jsx
+++ b/src/detail-panels/history/post/post-content-text.jsx
@@ -1,8 +1,7 @@
 // @ts-check
 
-import React from 'react';
 import { facetByteLength, overlapFacetsAndHighlights } from './facet-slice';
-import { Fragment } from 'react';
+import React, { Fragment } from 'react';
 
 /**
  * @param {{
@@ -14,7 +13,14 @@ import { Fragment } from 'react';
  *  textLightHighlights?: string
  * }} _
  */
-export function PostContentText({ className, highlightClassNameBase, text, facets, textHighlights, textLightHighlights }) {
+export function PostContentText({
+  className,
+  highlightClassNameBase,
+  text,
+  facets,
+  textHighlights,
+  textLightHighlights,
+}) {
   const breakLines = (text || '').split(/\r|\n/g);
 
   /** @type {({ charOffset: number, byteOffset: number, byteLength: number, line: string }[] | null)[]} */
@@ -38,7 +44,8 @@ export function PostContentText({ className, highlightClassNameBase, text, facet
       blocks.push([{ charOffset, byteOffset, byteLength, line }]);
     } else {
       let paragraph = !blocks.length ? undefined : blocks[blocks.length - 1];
-      if (!paragraph) blocks.push([{ charOffset, byteOffset, byteLength, line }]);
+      if (!paragraph)
+        blocks.push([{ charOffset, byteOffset, byteLength, line }]);
       else {
         paragraph.push({ charOffset, byteOffset, byteLength, line });
       }
@@ -52,58 +59,126 @@ export function PostContentText({ className, highlightClassNameBase, text, facet
   let blockCount = 0;
 
   let nextFacet = 0;
-  if (facets && facets.length > 1) // sort facets by byteStart
-    facets = facets.slice().sort((f1, f2) => f1.index?.byteStart - f2.index?.byteStart);
+  if (facets && facets.length > 1)
+    // sort facets by byteStart
+    facets = facets
+      .slice()
+      .sort((f1, f2) => f1.index?.byteStart - f2.index?.byteStart);
 
   const blockElements = blocks.map((entry, iBlock) => {
     if (!entry) return <br key={iBlock} />;
 
-    const lineElements = entry.map(({ charOffset, byteOffset, byteLength, line }, lineIndex) => {
-      const lineHighlights = overlapFacetsAndHighlights(
-        line,
-        byteOffset,
-        facets,
-        textHighlights,
-        textLightHighlights
-      );
+    const lineElements = entry.map(
+      ({ charOffset, byteOffset, byteLength, line }, lineIndex) => {
+        const lineHighlights = overlapFacetsAndHighlights(
+          line,
+          byteOffset,
+          facets,
+          textHighlights,
+          textLightHighlights
+        );
 
-      const lineChunks = lineHighlights.map((chunk, iChunk) => {
-        if (typeof chunk === 'string') return chunk;
-        if (chunk.facet) return <RenderFacet key={iChunk} className={highlightClassNameBase} facet={chunk.facet} isHighlight={chunk.isHighlight} isLightHighlight={chunk.isLightHighlight}>{chunk.text}</RenderFacet>;
-        else return <RenderHighlight key={iChunk} className={highlightClassNameBase} isHighlight={chunk.isHighlight} isLightHighlight={chunk.isLightHighlight}>{chunk.text}</RenderHighlight>;
-      });
+        const lineChunks = lineHighlights.map((chunk, iChunk) => {
+          if (typeof chunk === 'string') return chunk;
+          if (chunk.facet)
+            return (
+              <RenderFacet
+                key={iChunk}
+                className={highlightClassNameBase}
+                facet={chunk.facet}
+                isHighlight={chunk.isHighlight}
+                isLightHighlight={chunk.isLightHighlight}
+              >
+                {chunk.text}
+              </RenderFacet>
+            );
+          else
+            return (
+              <RenderHighlight
+                key={iChunk}
+                className={highlightClassNameBase}
+                isHighlight={chunk.isHighlight}
+                isLightHighlight={chunk.isLightHighlight}
+              >
+                {chunk.text}
+              </RenderHighlight>
+            );
+        });
 
-      return <Fragment key={lineIndex}>{lineChunks}</Fragment>;
-    });
+        return <Fragment key={lineIndex}>{lineChunks}</Fragment>;
+      }
+    );
 
     blockCount++;
     return (
-      <p key={iBlock} className={className ? className + ' ' + className + '-' + blockCount : undefined}>
+      <p
+        key={iBlock}
+        className={
+          className ? className + ' ' + className + '-' + blockCount : undefined
+        }
+      >
         {lineElements}
       </p>
     );
   });
 
+  return <>{blockElements}</>;
+}
+
+/**
+ *
+ * @param {{
+ * className?: string | undefined;
+ * facet?: boolean;
+ * isHighlight?: boolean;
+ * isLightHighlight?: boolean;
+ * children: React.ReactNode }} param0
+ * @returns
+ */
+function RenderFacet({
+  className = '',
+  facet,
+  isHighlight,
+  isLightHighlight,
+  children,
+}) {
   return (
-    <>{blockElements}</>
+    <a
+      target="_blank"
+      className={
+        (!facet ? '' : className + '-facet ') +
+        (!isHighlight ? '' : className + '-highlight ') +
+        (!isLightHighlight ? '' : className + '-light-highlight ')
+      }
+    >
+      {children}
+    </a>
   );
 }
 
-function RenderFacet({ className, facet, isHighlight, isLightHighlight, children }) {
+/**
+ *
+ * @param {{
+ * className?: string | undefined;
+ * isHighlight?: boolean;
+ * isLightHighlight?: boolean;
+ * children: React.ReactNode }} param0
+ * @returns
+ */
+function RenderHighlight({
+  className = '',
+  isHighlight,
+  isLightHighlight,
+  children,
+}) {
   return (
-    <a target='_blank' className={
-      (!facet ? '' : className + '-facet ') +
-      (!isHighlight ? '' : className + '-highlight ') +
-      (!isLightHighlight ? '' : className + '-light-highlight ')
-    }>{children}</a>
-  );
-}
-
-function RenderHighlight({ className, isHighlight, isLightHighlight, children }) {
-  return (
-    <span className={
-      (!isHighlight ? '' : className + '-highlight ') +
-      (!isLightHighlight ? '' : className + '-light-highlight ')
-    }>{children}</span>
+    <span
+      className={
+        (!isHighlight ? '' : className + '-highlight ') +
+        (!isLightHighlight ? '' : className + '-light-highlight ')
+      }
+    >
+      {children}
+    </span>
   );
 }

--- a/src/detail-panels/history/post/post-embed.jsx
+++ b/src/detail-panels/history/post/post-embed.jsx
@@ -93,9 +93,8 @@ function PostEmbedRecord({ embed, disableEmbedQT, level }) {
  * }} _
  */
 function PostEmbedImages({ post, embed }) {
-  if (!embed.images?.length) return null;
-
   const postUri = breakFeedUri(post.uri);
+  if (!embed.images?.length || !postUri) return null;
 
   if (embed.images.length === 1) {
     return (
@@ -184,6 +183,7 @@ function PostEmbedRecordWithMedia({ post, embed }) {
     );
   const postUri = breakFeedUri(post.uri);
   const { data } = usePostByUri(embed.record.record.uri);
+  if (!postUri) return null;
   return (
     <div className="post-content-embed">
       {!images?.length ? null : images.length === 1 ? (
@@ -227,6 +227,8 @@ function PostEmbedRecordWithMedia({ post, embed }) {
  */
 function PostEmbedExternal({ post, embed }) {
   const postUri = breakFeedUri(post.uri);
+  if (!postUri) return null;
+
   return (
     <div className="post-content-embed">
       <a

--- a/src/detail-panels/history/post/post-embed.jsx
+++ b/src/detail-panels/history/post/post-embed.jsx
@@ -7,6 +7,12 @@ import { usePostByUri } from '../../../api/post-history';
 
 import { RenderPost } from './render-post';
 import { localise } from '../../../localisation';
+import {
+  AppBskyEmbedExternal,
+  AppBskyEmbedImages,
+  AppBskyEmbedRecord,
+  AppBskyEmbedRecordWithMedia,
+} from '@atproto/api';
 
 /**
  * @param {{
@@ -17,26 +23,43 @@ import { localise } from '../../../localisation';
  * }} _
  */
 export function PostEmbed({ post, embed, disableEmbedQT, level }) {
-
   if (!embed || !post) return null;
   if (disableEmbedQT === true) return null;
-  if (typeof disableEmbedQT === 'function' && disableEmbedQT(level || 0, post)) return null;
+  if (typeof disableEmbedQT === 'function' && disableEmbedQT(level || 0, post))
+    return null;
 
-  switch (embed.$type) {
-    // @ts-ignore
-    case 'app.bsky.embed.record': return <PostEmbedRecord post={post} embed={embed} disableEmbedQT={disableEmbedQT} level={(level || 0) + 1} />;
-    // @ts-ignore
-    case 'app.bsky.embed.images': return <PostEmbedImages post={post} embed={embed} />;
-    // @ts-ignore
-    case 'app.bsky.embed.recordWithMedia': return <PostEmbedRecordWithMedia post={post} embed={embed} />;
-    // @ts-ignore
-    case 'app.bsky.embed.external': return <PostEmbedExternal post={post} embed={embed} />;
-    default: return (
-      <pre style={{ font: 'inherit', border: 'solid 1px silver', borderRadius: '1em' }}>
-        {JSON.stringify(embed, null, 2)}
-      </pre>
+  if (AppBskyEmbedRecord.isMain(embed)) {
+    return (
+      <PostEmbedRecord
+        post={post}
+        embed={embed}
+        disableEmbedQT={disableEmbedQT}
+        level={(level || 0) + 1}
+      />
     );
   }
+  if (AppBskyEmbedImages.isMain(embed)) {
+    return <PostEmbedImages post={post} embed={embed} />;
+  }
+  if (AppBskyEmbedRecordWithMedia.isMain(embed)) {
+    return <PostEmbedRecordWithMedia post={post} embed={embed} />;
+  }
+  if (AppBskyEmbedExternal.isMain(embed)) {
+    return <PostEmbedExternal post={post} embed={embed} />;
+  }
+
+  // fallback for unsupported embed
+  return (
+    <pre
+      style={{
+        font: 'inherit',
+        border: 'solid 1px silver',
+        borderRadius: '1em',
+      }}
+    >
+      {JSON.stringify(embed, null, 2)}
+    </pre>
+  );
 }
 
 /**
@@ -49,9 +72,16 @@ export function PostEmbed({ post, embed, disableEmbedQT, level }) {
  */
 function PostEmbedRecord({ embed, disableEmbedQT, level }) {
   const { data } = usePostByUri(embed.record.uri);
-  return !data ? 'Loading...' : (
-    <div className='post-content-embed'>
-      <RenderPost post={data} disableEmbedQT={disableEmbedQT} level={level} className='post-content-embed-qt' />
+  return !data ? (
+    'Loading...'
+  ) : (
+    <div className="post-content-embed">
+      <RenderPost
+        post={data}
+        disableEmbedQT={disableEmbedQT}
+        level={level}
+        className="post-content-embed-qt"
+      />
     </div>
   );
 }
@@ -69,48 +99,74 @@ function PostEmbedImages({ post, embed }) {
 
   if (embed.images.length === 1) {
     return (
-      <div className='post-content-embed'>
+      <div className="post-content-embed">
         <ImageWithAlt
-          className='post-content-embed-image-with-alt post-content-embed-image-with-alt-single'
-          src={getFeedBlobUrl(postUri?.shortDID, embed.images[0].image.ref + '')}
-          imageClassName='post-content-embed-image post-content-embed-image-single'
-          altClassName='post-content-embed-image-alt'
-          alt={embed.images[0].alt} />
+          className="post-content-embed-image-with-alt post-content-embed-image-with-alt-single"
+          src={getFeedBlobUrl(
+            postUri?.shortDID,
+            embed.images[0].image.ref + ''
+          )}
+          imageClassName="post-content-embed-image post-content-embed-image-single"
+          altClassName="post-content-embed-image-alt"
+          alt={embed.images[0].alt}
+        />
       </div>
     );
   }
 
   return (
-    <div className='post-content-embed'>
-      {
-        embed.images.map((image, i) =>
-          <ImageWithAlt
-            key={image.ref + '\n' + i}
-            className='post-content-embed-image-with-alt post-content-embed-image-with-alt-multiple'
-            src={getFeedBlobUrl(postUri?.shortDID, image.image.ref + '')}
-            imageClassName='post-content-embed-image post-content-embed-image-single'
-            altClassName='post-content-embed-image-alt'
-            alt={image.alt} />)
-      }
+    <div className="post-content-embed">
+      {embed.images.map((image, i) => (
+        <ImageWithAlt
+          key={image.ref + '\n' + i}
+          className="post-content-embed-image-with-alt post-content-embed-image-with-alt-multiple"
+          src={getFeedBlobUrl(postUri?.shortDID, image.image.ref + '')}
+          imageClassName="post-content-embed-image post-content-embed-image-single"
+          altClassName="post-content-embed-image-alt"
+          alt={image.alt}
+        />
+      ))}
     </div>
   );
 }
 
-function ImageWithAlt({ className, Component = 'span', imageClassName, altClassName, src, alt, ...rest }) {
-  const [expanded, setExpanded] = useState(/** @type {boolean | undefined} */(undefined));
+/**
+ * @param {{
+ *  className: string;
+ *  Component?: string;
+ *  imageClassName: string;
+ *  altClassName: string;
+ *  src: string | undefined;
+ *  alt: string;
+ * }} _
+ */
+function ImageWithAlt({
+  className,
+  Component = 'span',
+  imageClassName,
+  altClassName,
+  src,
+  alt,
+  ...rest
+}) {
+  const [expanded, setExpanded] = useState(
+    /** @type {boolean | undefined} */ (undefined)
+  );
 
   return (
     // @ts-ignore
     <Component {...rest} className={className}>
       <img src={src} className={imageClassName} />
-      {
-        alt &&
-        <div className={altClassName}
+      {(alt && (
+        <div
+          className={altClassName}
           style={expanded ? { height: 'auto' } : undefined}
-          onClick={() => setExpanded(!expanded)}>
+          onClick={() => setExpanded(!expanded)}
+        >
           {alt}
-        </div> || undefined
-      }
+        </div>
+      )) ||
+        undefined}
     </Component>
   );
 }
@@ -122,33 +178,43 @@ function ImageWithAlt({ className, Component = 'span', imageClassName, altClassN
  * }} _
  */
 function PostEmbedRecordWithMedia({ post, embed }) {
-  const images = /** @type {import('@atproto/api').AppBskyEmbedImages.Main['images']} */(embed.media?.images);
+  const images =
+    /** @type {import('@atproto/api').AppBskyEmbedImages.Main['images']} */ (
+      embed.media?.images
+    );
   const postUri = breakFeedUri(post.uri);
   const { data } = usePostByUri(embed.record.record.uri);
   return (
-    <div className='post-content-embed'>
-      {
-        !images?.length ? null :
-          images.length === 1 ?
-            <ImageWithAlt
-              className='post-content-embed-image-with-alt post-content-embed-image-with-alt-single'
-              src={getFeedBlobUrl(postUri?.shortDID, images[0].image.ref + '')}
-              imageClassName='post-content-embed-image post-content-embed-image-single'
-              altClassName='post-content-embed-image-alt'
-              alt={images[0].alt} /> :
-            images.map((image, i) =>
-              <ImageWithAlt
-                key={image.ref + ''}
-                className='post-content-embed-image-with-alt post-content-embed-image-with-alt-multiple'
-                src={getFeedBlobUrl(postUri?.shortDID, image.image.ref + '')}
-                imageClassName='post-content-embed-image post-content-embed-image-single'
-                altClassName='post-content-embed-image-alt'
-                alt={image.alt} />)
-      }
-      {
-        !data ? localise('Loading...', {uk: 'Зачекайте...'}) :
-          <RenderPost post={data} disableEmbedQT className='post-content-embed-qt' />
-      }
+    <div className="post-content-embed">
+      {!images?.length ? null : images.length === 1 ? (
+        <ImageWithAlt
+          className="post-content-embed-image-with-alt post-content-embed-image-with-alt-single"
+          src={getFeedBlobUrl(postUri?.shortDID, images[0].image.ref + '')}
+          imageClassName="post-content-embed-image post-content-embed-image-single"
+          altClassName="post-content-embed-image-alt"
+          alt={images[0].alt}
+        />
+      ) : (
+        images.map((image, i) => (
+          <ImageWithAlt
+            key={image.ref + ''}
+            className="post-content-embed-image-with-alt post-content-embed-image-with-alt-multiple"
+            src={getFeedBlobUrl(postUri?.shortDID, image.image.ref + '')}
+            imageClassName="post-content-embed-image post-content-embed-image-single"
+            altClassName="post-content-embed-image-alt"
+            alt={image.alt}
+          />
+        ))
+      )}
+      {!data ? (
+        localise('Loading...', { uk: 'Зачекайте...' })
+      ) : (
+        <RenderPost
+          post={data}
+          disableEmbedQT
+          className="post-content-embed-qt"
+        />
+      )}
     </div>
   );
 }
@@ -162,16 +228,25 @@ function PostEmbedRecordWithMedia({ post, embed }) {
 function PostEmbedExternal({ post, embed }) {
   const postUri = breakFeedUri(post.uri);
   return (
-    <div className='post-content-embed'>
-      <a className='post-embed-external'
+    <div className="post-content-embed">
+      <a
+        className="post-embed-external"
         href={embed.external.uri}
-        target='_blank'>
-        <div className='post-embed-external-title'>{embed.external.title}</div>
-        <div className='post-embed-external-description'>{embed.external.description}</div>
-        {
-          embed.external.thumb &&
-          <img src={getFeedBlobUrl(postUri?.shortDID, embed.external.thumb.ref + '')} className='post-embed-external-thumb' />
-        }
+        target="_blank"
+      >
+        <div className="post-embed-external-title">{embed.external.title}</div>
+        <div className="post-embed-external-description">
+          {embed.external.description}
+        </div>
+        {embed.external.thumb && (
+          <img
+            src={getFeedBlobUrl(
+              postUri?.shortDID,
+              embed.external.thumb.ref + ''
+            )}
+            className="post-embed-external-thumb"
+          />
+        )}
       </a>
     </div>
   );

--- a/src/detail-panels/history/post/render-post.jsx
+++ b/src/detail-panels/history/post/render-post.jsx
@@ -1,7 +1,12 @@
 // @ts-check
-/// <reference path="../../../types.d.ts" />
 
-import { breakFeedUri, likelyDID, unwrapShortDID, unwrapShortHandle, useResolveHandleOrDid } from '../../../api';
+import {
+  breakFeedUri,
+  likelyDID,
+  unwrapShortDID,
+  unwrapShortHandle,
+  useResolveHandleOrDid,
+} from '../../../api';
 import { usePostByUri } from '../../../api/post-history';
 
 import { Tooltip } from '@mui/material';
@@ -23,13 +28,23 @@ import { localise } from '../../../localisation';
  *  textLightHighlights?: string
  * }} _
  */
-export function RenderPost({ post, className, disableEmbedQT, level, textHighlights, textLightHighlights, ...rest }) {
+export function RenderPost({
+  post,
+  className,
+  disableEmbedQT,
+  level,
+  textHighlights,
+  textLightHighlights,
+  ...rest
+}) {
   if (!post) return undefined;
-  const postUri = breakFeedUri(/** @type {string} */(post.uri));
+  const postUri = breakFeedUri(/** @type {string} */ (post.uri));
   const account = useResolveHandleOrDid(postUri?.shortDID);
 
   return (
-    <div {...rest} className={'post-with-content ' + (className || '')}
+    <div
+      {...rest}
+      className={'post-with-content ' + (className || '')}
       onClick={(e) => {
         e.preventDefault();
         // TODO render threads somehow?
@@ -39,56 +54,70 @@ export function RenderPost({ post, className, disableEmbedQT, level, textHighlig
         //     console.log('thread post', p);
         //   }
         // });
-      }}>
-      <h4 className='post-header'>
-        {
-          !postUri?.shortDID ? <UnknownAccountHeader post={post} /> :
-            <>
-              <AccountShortEntry
-                account={postUri?.shortDID}
-              />
-              <FormatTimestamp
-                className='post-timestamp'
-                timestamp={post.createdAt}
-                Component='a'
-                href={createPostHref(account.data?.shortHandle, postUri?.postID)}
-                target='_blank'
-                tooltipExtra={
-                  <div className='post-timestamp-tooltip'>
-                    <div className='post-timestamp-tooltip-post-uri'>
-                      {post.uri}
-                    </div>
-                    {localise('Open in new tab', { uk: 'Відкрити в новій вкладці' })}
+      }}
+    >
+      <h4 className="post-header">
+        {!postUri?.shortDID ? (
+          <UnknownAccountHeader post={post} />
+        ) : (
+          <>
+            <AccountShortEntry account={postUri?.shortDID} />
+            <FormatTimestamp
+              className="post-timestamp"
+              timestamp={post.createdAt}
+              Component="a"
+              href={createPostHref(account.data?.shortHandle, postUri?.postID)}
+              target="_blank"
+              tooltipExtra={
+                <div className="post-timestamp-tooltip">
+                  <div className="post-timestamp-tooltip-post-uri">
+                    {post.uri}
                   </div>
-                }
-              />
-            </>
-        }
-        {
-          !post.reply ? undefined :
-            <>
-              <ReplyToLink post={post} className='post-replying-to-marker' />
-            </>
-        }
+                  {localise('Open in new tab', {
+                    uk: 'Відкрити в новій вкладці',
+                  })}
+                </div>
+              }
+            />
+          </>
+        )}
+        {!post.reply ? undefined : (
+          <>
+            <ReplyToLink post={post} className="post-replying-to-marker" />
+          </>
+        )}
       </h4>
       <PostContentText
-        className='post-content'
-        highlightClassNameBase='post-content-highlight'
+        className="post-content"
+        highlightClassNameBase="post-content-highlight"
         facets={post.facets}
         textHighlights={textHighlights}
         textLightHighlights={textLightHighlights}
-        text={post.text} />
+        text={post.text}
+      />
       {
-        <PostEmbed post={post} embed={post.embed} disableEmbedQT={disableEmbedQT} level={(level || 0) + 1} />
+        <PostEmbed
+          post={post}
+          embed={post.embed}
+          disableEmbedQT={disableEmbedQT}
+          level={(level || 0) + 1}
+        />
       }
     </div>
   );
 }
 
-
+/**
+ * @param {{
+ *  post: PostDetails,
+ * }} _
+ */
 function UnknownAccountHeader({ post }) {
-  const postUri = breakFeedUri(/** @type {string} */(post.uri));
-  return localise('Unknown account ', {uk: 'Невідомий акаунт '}) + (postUri?.shortDID || post.uri);
+  const postUri = breakFeedUri(/** @type {string} */ (post.uri));
+  return (
+    localise('Unknown account ', { uk: 'Невідомий акаунт ' }) +
+    (postUri?.shortDID || post.uri)
+  );
 }
 
 /**
@@ -108,28 +137,48 @@ function ReplyToLink({ post, ...rest }) {
 
   return (
     <span {...rest}>
-      {
-        !replyUri ? undefined :
-          <>
-            <span className='post-replying-to-marker-text'>&lsaquo;</span>
-            <Tooltip title={<RenderPostInTooltip postUri={post.reply?.parent?.uri} />}>
-              <a href={createPostHref(replyAccount.data?.shortHandle, replyUri?.postID)} target='_blank'>
-                <MiniAvatar className='post-replying-to-resolved' account={replyAccount.data} />
-              </a>
-            </Tooltip>
-          </>
-      }
-      {
-        !replyUri || rootUri?.shortDID === replyUri?.shortDID ? undefined :
-          <>
-            <span className='post-replying-to-marker-text'>&lsaquo;</span>
-            <Tooltip title={<RenderPostInTooltip postUri={post.reply?.root?.uri} />}>
-              <a href={createPostHref(rootAccount.data?.shortHandle, rootUri?.postID)} target='_blank'>
-                <MiniAvatar className='post-replying-to-resolved post-replying-to-root' account={rootAccount?.data} />
-              </a>
-            </Tooltip>
-          </>
-      }
+      {!replyUri ? undefined : (
+        <>
+          <span className="post-replying-to-marker-text">&lsaquo;</span>
+          <Tooltip
+            title={<RenderPostInTooltip postUri={post.reply?.parent?.uri} />}
+          >
+            <a
+              href={createPostHref(
+                replyAccount.data?.shortHandle,
+                replyUri?.postID
+              )}
+              target="_blank"
+            >
+              <MiniAvatar
+                className="post-replying-to-resolved"
+                account={replyAccount.data}
+              />
+            </a>
+          </Tooltip>
+        </>
+      )}
+      {!replyUri || rootUri?.shortDID === replyUri?.shortDID ? undefined : (
+        <>
+          <span className="post-replying-to-marker-text">&lsaquo;</span>
+          <Tooltip
+            title={<RenderPostInTooltip postUri={post.reply?.root?.uri} />}
+          >
+            <a
+              href={createPostHref(
+                rootAccount.data?.shortHandle,
+                rootUri?.postID
+              )}
+              target="_blank"
+            >
+              <MiniAvatar
+                className="post-replying-to-resolved post-replying-to-root"
+                account={rootAccount?.data}
+              />
+            </a>
+          </Tooltip>
+        </>
+      )}
     </span>
   );
 }
@@ -142,23 +191,29 @@ function ReplyToLink({ post, ...rest }) {
 function RenderPostInTooltip({ postUri }) {
   const { data } = usePostByUri(postUri);
   return (
-    <RenderPost post={data} disableEmbedQT className='post-content-embed-qt' />
+    <RenderPost post={data} disableEmbedQT className="post-content-embed-qt" />
   );
 }
 
-
 /**
  * @param {{
-*  account: AccountInfo | null,
-*  className?: string
-* }} _
-*/
+ *  account: AccountInfo | null | undefined,
+ *  className?: string
+ * }} _
+ */
 function MiniAvatar({ account, className, ...rest }) {
   return (
-    <span className={'post-replying-mini-avatar ' + (className || '')} style={
-      !account?.avatarUrl ? undefined :
-        { backgroundImage: `url(${account?.avatarUrl})` }
-    } {...rest}>{account?.displayName}</span>
+    <span
+      className={'post-replying-mini-avatar ' + (className || '')}
+      style={
+        !account?.avatarUrl
+          ? undefined
+          : { backgroundImage: `url(${account?.avatarUrl})` }
+      }
+      {...rest}
+    >
+      {account?.displayName}
+    </span>
   );
 }
 
@@ -168,6 +223,8 @@ function MiniAvatar({ account, className, ...rest }) {
  */
 function createPostHref(handleOrDID, postID) {
   if (!handleOrDID || !postID) return;
-  const identifier = likelyDID(handleOrDID) ? unwrapShortDID(handleOrDID) : unwrapShortHandle(handleOrDID);
+  const identifier = likelyDID(handleOrDID)
+    ? unwrapShortDID(handleOrDID)
+    : unwrapShortHandle(handleOrDID);
   return `https://bsky.app/profile/${identifier}/post/${postID}`;
 }

--- a/src/detail-panels/history/search-header.jsx
+++ b/src/detail-panels/history/search-header.jsx
@@ -1,6 +1,4 @@
 // @ts-check
-import React from 'react';
-
 import { TextField } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 
@@ -16,15 +14,17 @@ export function SearchHeader({ className, label, ...props }) {
     <div className={'history-header ' + (className || '')}>
       <TextField
         aria-label={typeof label === 'string' ? label : undefined}
-        name='q'
-        className='history-search-text-field'
+        name="q"
+        className="history-search-text-field"
         label={
           <>
-            <span className='history-search-text-search-icon'><SearchIcon /></span>
-            <span className='history-search-text-search-label'>{label}</span>
+            <span className="history-search-text-search-icon">
+              <SearchIcon />
+            </span>
+            <span className="history-search-text-search-label">{label}</span>
           </>
         }
-        variant='standard'
+        variant="standard"
         {...props}
       />
     </div>
@@ -34,21 +34,33 @@ export function SearchHeader({ className, label, ...props }) {
 /**
  * @param {Parameters<typeof TextField>[0] & { delay?: number, setQ?: boolean | string }} _
  */
-export function SearchHeaderDebounced({ value, onChange, delay, setQ, ...props }) {
+export function SearchHeaderDebounced({
+  value,
+  onChange,
+  delay,
+  setQ,
+  ...props
+}) {
   const [searchParams, setSearchParams] = useSearchParams();
   return (
     <OnChangeDebounced
       component={SearchHeader}
-      value={/** @type {string} */(value ?? (searchParams.get('q') || ''))}
-      onChange={e => {
-        /** @type {*} */(onChange)?.(e);
+      value={/** @type {string} */ (value ?? (searchParams.get('q') || ''))}
+      onChange={(e) => {
+        /** @type {*} */ (onChange)?.(e);
         if (setQ) {
-          const text = typeof e.target?.value === 'string' ? e.target.value : String(e.target?.value ?? '');
-          const q = setQ === true ? 'q' : setQ;
-          const params = { ...searchParams };
-          if (text) params[q] = text;
-          else delete params[q];
-          setSearchParams(params);
+          const text =
+            typeof e.target?.value === 'string'
+              ? e.target.value
+              : String(e.target?.value ?? '');
+          setSearchParams((prev) => {
+            if (text) {
+              prev.set('q', text);
+            } else {
+              prev.delete('q');
+            }
+            return prev;
+          });
         }
       }}
       delay={delay}

--- a/src/detail-panels/history/search/cached-search.jsx
+++ b/src/detail-panels/history/search/cached-search.jsx
@@ -11,7 +11,7 @@ const CachedSearchContext = React.createContext(
   ([])
 );
 
-export const WithSearchContext = CachedSearchContext.Consumer
+export const WithSearchContext = CachedSearchContext.Consumer;
 
 /**
  * @param {{
@@ -25,24 +25,30 @@ export function CachedSearch({ children, ...rest }) {
   const ranked = applySearchGetResults(rest);
   return (
     <CachedSearchContext.Provider value={ranked}>
-      {
-        typeof children === 'function' ?
-          children(ranked) :
-          children
-      }
+      {typeof children === 'function' ? children(ranked) : children}
     </CachedSearchContext.Provider>
   );
 }
 
 /**
+ * @typedef {{ searchText: string | undefined, posts: PostDetails[], ranked: ReturnType<typeof applySearch>, timestamp: number }} SearchCacheEntry
+ */
+
+/**
  * @param {{
  *  searchText: string | undefined,
  *  posts: PostDetails[],
- *  cachedSearches: { searchText: string | undefined, posts: PostDetails[], ranked: ReturnType<typeof applySearch>, timestamp: number }[]
+ *  cachedSearches: SearchCacheEntry[],
  * }} _
  */
 export function applySearchGetResults({ searchText, posts, cachedSearches }) {
-  if (!searchText) return posts.map(post => ({ post, rank: 0, textHighlights: undefined, textLightHighlights: undefined }));
+  if (!searchText)
+    return posts.map((post) => ({
+      post,
+      rank: 0,
+      textHighlights: undefined,
+      textLightHighlights: undefined,
+    }));
 
   let earliestCacheIndex = 0;
   for (let i = 0; i < cachedSearches.length; i++) {
@@ -76,6 +82,11 @@ export function applySearchGetResults({ searchText, posts, cachedSearches }) {
   if (cachedSearches.length >= MAX_SEARCH_CACHE) {
     cachedSearches.splice(earliestCacheIndex, 1);
   }
-  cachedSearches.push({ searchText, posts: posts.slice(), ranked, timestamp: Date.now() });
+  cachedSearches.push({
+    searchText,
+    posts: posts.slice(),
+    ranked,
+    timestamp: Date.now(),
+  });
   return ranked;
 }

--- a/src/detail-panels/layout.jsx
+++ b/src/detail-panels/layout.jsx
@@ -33,12 +33,10 @@ export function AccountLayout() {
 
   return (
     <AccountLayoutCore
+      // @ts-expect-error no guarantee that the url param is one of our known tabs
       selectedTab={tab}
       onSetSelectedTab={(selectedTab) => {
-        navigate(
-          `/${handle}/` + selectedTab,
-          { replace: true }
-        );
+        navigate(`/${handle}/` + selectedTab, { replace: true });
       }}
       onCloseClick={() => {
         navigate('/');
@@ -50,7 +48,7 @@ export function AccountLayout() {
 /**
  *
  * @param {{
- *   selectedTab: string,
+ *   selectedTab: import('./tab-selector').AnyTab,
  * onCloseClick: () => void,
  * onSetSelectedTab: (tab:string) => void,
  * }} param0

--- a/src/detail-panels/tab-selector.jsx
+++ b/src/detail-panels/tab-selector.jsx
@@ -9,25 +9,35 @@ import { accountTabs } from './layout';
 import './tab-selector.css';
 import { localise } from '../localisation';
 
-export function TabSelector({ className, tab, onTabSelected }) {
+/** @typedef {accountTabs[number]} AnyTab */
 
+/**
+ *
+ * @param {{ className: string, tab: AnyTab, onTabSelected(tab: AnyTab): void }} param0
+ * @returns
+ */
+export function TabSelector({ className, tab, onTabSelected }) {
   const tabHandlers = {
-    'blocked-by':
-      <VerticalTab key='blocked-by' className='tab-blocked-by'>
+    'blocked-by': (
+      <VerticalTab key="blocked-by" className="tab-blocked-by">
         {localise('Blocked By', { uk: 'Блокують' })}
-      </VerticalTab>,
-    'blocking':
-      <VerticalTab key='blocking' className='tab-blocking'>
+      </VerticalTab>
+    ),
+    blocking: (
+      <VerticalTab key="blocking" className="tab-blocking">
         {localise('Blocking', { uk: 'Блокує' })}
-      </VerticalTab>,
-    'lists':
-      <VerticalTab key='lists' className='tab-lists'>
+      </VerticalTab>
+    ),
+    lists: (
+      <VerticalTab key="lists" className="tab-lists">
         {localise('Lists', { uk: 'У списках' })}
-      </VerticalTab>,
-    'history':
-      <VerticalTab key='history' className='tab-history'>
+      </VerticalTab>
+    ),
+    history: (
+      <VerticalTab key="history" className="tab-history">
         {localise('History', { uk: 'Історія' })}
       </VerticalTab>
+    ),
   };
 
   return (
@@ -37,28 +47,25 @@ export function TabSelector({ className, tab, onTabSelected }) {
         orientation="vertical"
         value={accountTabs.indexOf(tab)}
         onChange={
-          typeof onTabSelected !== 'function' ? undefined :
-            (event, newValue) => onTabSelected(accountTabs[newValue])
+          typeof onTabSelected !== 'function'
+            ? undefined
+            : (event, newValue) => onTabSelected(accountTabs[newValue])
         }
       >
-        {accountTabs.map(tabKey => tabHandlers[tabKey])}
+        {accountTabs.map((tabKey) => tabHandlers[tabKey])}
       </Tabs>
 
-      <div className='bluethernal-llc-watermark'>
-        Bluethernal LLC
-      </div>
+      <div className="bluethernal-llc-watermark">Bluethernal LLC</div>
     </div>
   );
 }
 
+/** @param {Omit<import('@emotion/react').PropsOf<Tab>, "children"> & { children: React.ReactNode }} param0 */
 function VerticalTab({ children, ...rest }) {
   return (
     <Tab
-      label={
-        <div style={{ writingMode: 'vertical-rl' }}>
-          {children}
-        </div>
-      }
-      {...rest} />
+      label={<div style={{ writingMode: 'vertical-rl' }}>{children}</div>}
+      {...rest}
+    />
   );
 }

--- a/src/landing/about/about.jsx
+++ b/src/landing/about/about.jsx
@@ -14,6 +14,11 @@ import './about.css';
 // @ts-ignore
 const builtFromCommit = BUILD_COMMIT_HASH || null;
 
+/**
+ *
+ * @param {{ onToggleAbout(): void; }} param0
+ * @returns
+ */
 export function About({ onToggleAbout }) {
   return (
     <div className="about">
@@ -30,7 +35,7 @@ export function About({ onToggleAbout }) {
           <a href="/terms-and-conditions.html">Terms and Conditions</a> |{' '}
           <a href="https://status.clearsky.app">Status</a>
         </span>
-        {localise('Version', {uk: 'Версія'})}: {version}{' '}
+        {localise('Version', { uk: 'Версія' })}: {version}{' '}
         {builtFromCommit && `(${builtFromCommit})`}
         <br />
         <h2 className="petition">

--- a/src/landing/home-stats/home-stats-main.jsx
+++ b/src/landing/home-stats/home-stats-main.jsx
@@ -51,15 +51,13 @@ export function HomeStatsMain({
       {stats && (
         <>
           <TopBlocked
-            blocked={isPromise(stats) ? undefined : stats.topLists.blocked}
-            blocked24={isPromise(stats) ? undefined : stats.topLists.blocked24}
+            blocked={stats.topLists.blocked}
+            blocked24={stats.topLists.blocked24}
           />
 
           <TopBlockers
-            blockers={isPromise(stats) ? undefined : stats.topLists.blockers}
-            blockers24={
-              isPromise(stats) ? undefined : stats.topLists.blockers24
-            }
+            blockers={stats.topLists.blockers}
+            blockers24={stats.topLists.blockers24}
           />
         </>
       )}

--- a/src/landing/home-stats/home-stats-table.jsx
+++ b/src/landing/home-stats/home-stats-table.jsx
@@ -23,129 +23,173 @@ export default function HomeStatsTable({
   stats,
   onToggleTable,
 }) {
-    const { allBlockedStats, topBlocked, topBlocked24, topBlockers, topBlockers24 } = useMemo(() => getGridRowsAndColumns(stats), [stats]);
+  const {
+    allBlockedStats,
+    topBlocked,
+    topBlocked24,
+    topBlockers,
+    topBlockers24,
+  } = useMemo(() => getGridRowsAndColumns(stats), [stats]);
 
-    const [activeTab, setActiveTab] = useState(0);
-    const tableData = [
-      { id: 1, name: localise('Overall Stats', {}), data: allBlockedStats, columnDefs: [
-          { field: 'category', headerName: 'Stats' },
-          { field: 'value'}
-        ]
-      },
-      { id: 2, name: localise('Top Blocked', {}), data: topBlocked, columnDefs: [
-          { field: 'handle', cellRenderer: HandleLinkRenderer},
-          {
-            field: 'count',
-            headerName: 'Count',
-            cellStyle: { textAlign: 'right' },
-          },
-          { field: 'did', headerName: 'DID' },
-        ]
-      },
-      { id: 3, name: localise('Top Blocked Last 24h', {}), data: topBlocked24, columnDefs: [
-          { field: 'handle', cellRenderer: HandleLinkRenderer},
-          {
-            field: 'count',
-            headerName: 'Count',
-            cellStyle: { textAlign: 'right' },
-          },
-          { field: 'did', headerName: 'DID' },
-        ]
-      },
-      { id: 4, name: localise('Top Blockers', {}), data: topBlockers, columnDefs: [
-          { field: 'handle', cellRenderer: HandleLinkRenderer},
-          {
-            field: 'count',
-            headerName: 'Count',
-            cellStyle: { textAlign: 'right' },
-          },
-          { field: 'did', headerName: 'DID' },
-        ]
-      },
-      { id: 5, name: localise('Top Blockers Last 24h', {}), data: topBlockers24, columnDefs: [
-          { field: 'handle', cellRenderer: HandleLinkRenderer},
-          {
-            field: 'count',
-            headerName: 'Count',
-            cellStyle: { textAlign: 'right' },
-          },
-          { field: 'did', headerName: 'DID' },
-        ]
-      }
-    ];
-    const handleChange = (event, newValue) => setActiveTab(newValue);
-  
-    return (
-      <div
-        className={'home-stats-table ' + (className || '')}
-        style={{ padding: '0 1em' }}
-      >
-        <div className="home-stats-table-container">
-          <div
-            className="as-of-subtitle"
-            style={{ fontSize: '60%', color: 'silver' }}
-          >
-            <i>{asofFormatted}</i>
-          </div>
-  
-          <div className="tabs">
-            <Box sx={{ width: '100%' }}>
-              <Tabs
-                value={activeTab}
-                onChange={handleChange}
-                variant="scrollable"
-                scrollButtons
-                allowScrollButtonsMobile            
-                textColor="primary"
-                indicatorColor="primary"
-                aria-label="primary scrollable block-stats tabs"
-              >
-                {tableData.map((table, index) => (
-                  <Tab key={table.id} value={index} label={table.name} />
-                ))}
-              </Tabs>
-            </Box>
-          </div>
-  
-          {loading ? undefined : (
-            <Button
-              variant="contained"
-              size="small"
-              className="toggle-table"
-              onClick={onToggleTable}
+  const [activeTab, setActiveTab] = useState(0);
+  const tableData = [
+    {
+      id: 1,
+      name: localise('Overall Stats', {}),
+      data: allBlockedStats,
+      /** @type {import('ag-grid-community').GridOptions['columnDefs']} */
+      columnDefs: [
+        { field: 'category', headerName: 'Stats' },
+        { field: 'value' },
+      ],
+    },
+    {
+      id: 2,
+      name: localise('Top Blocked', {}),
+      data: topBlocked,
+      /** @type {import('ag-grid-community').GridOptions['columnDefs']} */
+      columnDefs: [
+        { field: 'handle', cellRenderer: HandleLinkRenderer },
+        {
+          field: 'count',
+          headerName: 'Count',
+          cellStyle: { textAlign: 'right' },
+        },
+        { field: 'did', headerName: 'DID' },
+      ],
+    },
+    {
+      id: 3,
+      name: localise('Top Blocked Last 24h', {}),
+      data: topBlocked24,
+      /** @type {import('ag-grid-community').GridOptions['columnDefs']} */
+      columnDefs: [
+        { field: 'handle', cellRenderer: HandleLinkRenderer },
+        {
+          field: 'count',
+          headerName: 'Count',
+          cellStyle: { textAlign: 'right' },
+        },
+        { field: 'did', headerName: 'DID' },
+      ],
+    },
+    {
+      id: 4,
+      name: localise('Top Blockers', {}),
+      data: topBlockers,
+      /** @type {import('ag-grid-community').GridOptions['columnDefs']} */
+      columnDefs: [
+        { field: 'handle', cellRenderer: HandleLinkRenderer },
+        {
+          field: 'count',
+          headerName: 'Count',
+          cellStyle: { textAlign: 'right' },
+        },
+        { field: 'did', headerName: 'DID' },
+      ],
+    },
+    {
+      id: 5,
+      name: localise('Top Blockers Last 24h', {}),
+      data: topBlockers24,
+      /** @type {import('ag-grid-community').GridOptions['columnDefs']} */
+      columnDefs: [
+        { field: 'handle', cellRenderer: HandleLinkRenderer },
+        {
+          field: 'count',
+          headerName: 'Count',
+          cellStyle: { textAlign: 'right' },
+        },
+        { field: 'did', headerName: 'DID' },
+      ],
+    },
+  ];
+
+  return (
+    <div
+      className={'home-stats-table ' + (className || '')}
+      style={{ padding: '0 1em' }}
+    >
+      <div className="home-stats-table-container">
+        <div
+          className="as-of-subtitle"
+          style={{ fontSize: '60%', color: 'silver' }}
+        >
+          <i>{asofFormatted}</i>
+        </div>
+
+        <div className="tabs">
+          <Box sx={{ width: '100%' }}>
+            <Tabs
+              value={activeTab}
+              onChange={(event, newValue) => setActiveTab(newValue)}
+              variant="scrollable"
+              scrollButtons
+              allowScrollButtonsMobile
+              textColor="primary"
+              indicatorColor="primary"
+              aria-label="primary scrollable block-stats tabs"
             >
-              <ViewList />
-            </Button>
-          )}
-  
-          <div className="home-stats-table-host">
-            <AgGridReact
-              autoSizeStrategy={{type: 'fitCellContents', colIds: ['category', 'did']}}
-              defaultColDef={{
-                resizable: true,
-                sortable: false
-              }}
-              columnDefs={tableData[activeTab].columnDefs}
-              rowData={tableData[activeTab].data}
-            />
-          </div>
+              {tableData.map((table, index) => (
+                <Tab key={table.id} value={index} label={table.name} />
+              ))}
+            </Tabs>
+          </Box>
+        </div>
+
+        {loading ? undefined : (
+          <Button
+            variant="contained"
+            size="small"
+            className="toggle-table"
+            onClick={onToggleTable}
+          >
+            <ViewList />
+          </Button>
+        )}
+
+        <div className="home-stats-table-host">
+          <AgGridReact
+            autoSizeStrategy={{
+              type: 'fitCellContents',
+              colIds: ['category', 'did'],
+            }}
+            defaultColDef={{
+              resizable: true,
+              sortable: false,
+            }}
+            columnDefs={tableData[activeTab].columnDefs}
+            rowData={tableData[activeTab].data}
+          />
         </div>
       </div>
-    );
+    </div>
+  );
 }
 
-/** 
+/**
  * @param {DashboardStats} stats
  */
 function getGridRowsAndColumns(stats) {
-  const blockedData = {'allBlockedStats': [], 'topBlocked': [], 'topBlocked24': [], 'topBlockers': [], 'topBlockers24': []};
+  const blockedData = {
+    /** @type {Array<{category: string, value: string | undefined }>} */
+    allBlockedStats: [],
+    /** @type {Array<{did: string, count: number }>} */
+    topBlocked: [],
+    /** @type {Array<{did: string, count: number }>} */
+    topBlocked24: [],
+    /** @type {Array<{did: string, count: number }>} */
+    topBlockers: [],
+    /** @type {Array<{did: string, count: number }>} */
+    topBlockers24: [],
+  };
 
   if (stats.totalUsers) {
     /** @type {ValueWithDisplayName[]} */
     const totalStats = Object.values(stats.totalUsers);
     for (const stat of totalStats) {
-      if (typeof stat.displayName === "undefined") {
-        continue
+      if (typeof stat.displayName === 'undefined') {
+        continue;
       }
       blockedData['allBlockedStats'].push({
         category: stat.displayName,
@@ -168,44 +212,50 @@ function getGridRowsAndColumns(stats) {
     for (const [key, value] of Object.entries(stats.topLists.blocked)) {
       blockedData['topBlocked'].push({
         did: key,
-        count: value.count.toLocaleString()
+        count: value.count,
       });
     }
 
-    blockedData['topBlocked'].sort((a, b) => parseInt(b.count) - parseInt(a.count))
+    blockedData['topBlocked'].sort((a, b) => b.count - a.count);
   }
 
-  if (stats.topLists.blocked24 && Object.keys(stats.topLists.blocked24).length) {
+  if (
+    stats.topLists.blocked24 &&
+    Object.keys(stats.topLists.blocked24).length
+  ) {
     for (const [key, value] of Object.entries(stats.topLists.blocked24)) {
       blockedData['topBlocked24'].push({
         did: key,
-        count: value.count.toLocaleString()
+        count: value.count,
       });
     }
 
-    blockedData['topBlocked24'].sort((a, b) => parseInt(b.count) - parseInt(a.count))
+    blockedData['topBlocked24'].sort((a, b) => b.count - a.count);
   }
 
   if (stats.topLists.blockers && Object.keys(stats.topLists.blockers).length) {
     for (const [key, value] of Object.entries(stats.topLists.blockers)) {
       blockedData['topBlockers'].push({
         did: key,
-        count: value.count.toLocaleString()
+        count: value.count,
       });
     }
 
-    blockedData['topBlockers'].sort((a, b) => parseInt(b.count) - parseInt(a.count))
+    blockedData['topBlockers'].sort((a, b) => b.count - a.count);
   }
 
-  if (stats.topLists.blockers24 && Object.keys(stats.topLists.blockers24).length) {
+  if (
+    stats.topLists.blockers24 &&
+    Object.keys(stats.topLists.blockers24).length
+  ) {
     for (const [key, value] of Object.entries(stats.topLists.blockers24)) {
       blockedData['topBlockers24'].push({
         did: key,
-        count: value.count.toLocaleString()
+        count: value.count,
       });
     }
 
-    blockedData['topBlockers24'].sort((a, b) => parseInt(b.count) - parseInt(a.count))
+    blockedData['topBlockers24'].sort((a, b) => b.count - a.count);
   }
 
   return blockedData;
@@ -269,7 +319,7 @@ function getLabelForStatKey(key) {
 
 /**
  * @param {import('ag-grid-community').ICellRendererParams} params
- * 
+ *
  * @returns {JSX.Element | string}
  */
 function HandleLinkRenderer(params) {

--- a/src/landing/home-stats/home-stats-table.jsx
+++ b/src/landing/home-stats/home-stats-table.jsx
@@ -174,14 +174,10 @@ function getGridRowsAndColumns(stats) {
   const blockedData = {
     /** @type {Array<{category: string, value: string | undefined }>} */
     allBlockedStats: [],
-    /** @type {Array<{did: string, count: number }>} */
-    topBlocked: [],
-    /** @type {Array<{did: string, count: number }>} */
-    topBlocked24: [],
-    /** @type {Array<{did: string, count: number }>} */
-    topBlockers: [],
-    /** @type {Array<{did: string, count: number }>} */
-    topBlockers24: [],
+    topBlocked: blockListToArray(stats.topLists.blocked),
+    topBlocked24: blockListToArray(stats.topLists.blocked24),
+    topBlockers: blockListToArray(stats.topLists.blockers),
+    topBlockers24: blockListToArray(stats.topLists.blockers24),
   };
 
   if (stats.totalUsers) {
@@ -208,57 +204,24 @@ function getGridRowsAndColumns(stats) {
     }
   }
 
-  if (stats.topLists.blocked && Object.keys(stats.topLists.blocked).length) {
-    for (const [key, value] of Object.entries(stats.topLists.blocked)) {
-      blockedData['topBlocked'].push({
-        did: key,
-        count: value.count,
-      });
-    }
-
-    blockedData['topBlocked'].sort((a, b) => b.count - a.count);
-  }
-
-  if (
-    stats.topLists.blocked24 &&
-    Object.keys(stats.topLists.blocked24).length
-  ) {
-    for (const [key, value] of Object.entries(stats.topLists.blocked24)) {
-      blockedData['topBlocked24'].push({
-        did: key,
-        count: value.count,
-      });
-    }
-
-    blockedData['topBlocked24'].sort((a, b) => b.count - a.count);
-  }
-
-  if (stats.topLists.blockers && Object.keys(stats.topLists.blockers).length) {
-    for (const [key, value] of Object.entries(stats.topLists.blockers)) {
-      blockedData['topBlockers'].push({
-        did: key,
-        count: value.count,
-      });
-    }
-
-    blockedData['topBlockers'].sort((a, b) => b.count - a.count);
-  }
-
-  if (
-    stats.topLists.blockers24 &&
-    Object.keys(stats.topLists.blockers24).length
-  ) {
-    for (const [key, value] of Object.entries(stats.topLists.blockers24)) {
-      blockedData['topBlockers24'].push({
-        did: key,
-        count: value.count,
-      });
-    }
-
-    blockedData['topBlockers24'].sort((a, b) => b.count - a.count);
-  }
-
   return blockedData;
+}
+
+function blockListToArray(/** @type {BlockList | null} */ list) {
+  if (!list) return [];
+  if (Array.isArray(list)) return list;
+
+  /** @type {BlockData[]} */
+  const ret = [];
+  for (const [key, value] of Object.entries(list)) {
+    ret.push({
+      did: key,
+      count: value.count,
+    });
+  }
+
+  ret.sort((a, b) => b.count - a.count);
+  return ret;
 }
 
 /**

--- a/src/landing/home-stats/index.jsx
+++ b/src/landing/home-stats/index.jsx
@@ -16,7 +16,7 @@ const HomeStatsTable = lazy(() => import('./home-stats-table'));
  *  percentNumberBlocked1: number | undefined;
  *  percentNumberBlocking1: number | undefined;
  *  loading: boolean;
- *  stats: DashboardStats | undefined;
+ *  stats: DashboardStats;
  *  onToggleTable?: () => void;
  * }} HomeStatsDetails
  */
@@ -31,13 +31,14 @@ export function HomeStats({ className }) {
 
   const { data: stats, isLoading } = useDashboardStats();
 
-  const asofFormatted = stats?.asof && new Date(stats.asof) + '';
+  const asofFormatted = stats.asof && new Date(stats.asof) + '';
 
-  const activeAccounts = stats?.totalUsers?.active_count?.value
-  const deletedAccounts = stats?.totalUsers?.deleted_count?.value
-  const percentNumberBlocked1 = stats?.blockStats?.percentNumberBlocked1;
-  const percentNumberBlocking1 = stats?.blockStats?.percentNumberBlocking1;
+  const activeAccounts = stats.totalUsers?.active_count?.value;
+  const deletedAccounts = stats.totalUsers?.deleted_count?.value;
+  const percentNumberBlocked1 = stats.blockStats?.percentNumberBlocked1;
+  const percentNumberBlocking1 = stats.blockStats?.percentNumberBlocking1;
 
+  /** @type {HomeStatsDetails} */
   const arg = {
     className,
     asofFormatted,
@@ -47,9 +48,11 @@ export function HomeStats({ className }) {
     percentNumberBlocking1,
     loading: isLoading,
     stats,
+    onToggleTable() {
+      setAsTable((prev) => !prev);
+    },
   };
 
-  if (asTable)
-    return <HomeStatsTable {...arg} onToggleTable={() => setAsTable(false)} />;
-  else return <HomeStatsMain {...arg} onToggleTable={() => setAsTable(true)} />;
+  if (asTable) return <HomeStatsTable {...arg} />;
+  else return <HomeStatsMain {...arg} />;
 }

--- a/src/landing/home-stats/infographics/face-svg.jsx
+++ b/src/landing/home-stats/infographics/face-svg.jsx
@@ -1,18 +1,26 @@
 // @ts-check
 
 import React from 'react';
-
 import './face-svg.css';
 
+/**
+ *
+ * @param {React.SVGProps<SVGSVGElement>} _
+ * @returns
+ */
 export function FaceSvg({ className, ...props }) {
-
   return (
     <svg
       {...props}
-      className={'MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiBox-root SvgIcon-FaceSvg ' + (className || '')}
-      viewBox="0 0 24 24" data-testid="FaceSvg"
+      className={
+        'MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiBox-root SvgIcon-FaceSvg ' +
+        (className || '')
+      }
+      viewBox="0 0 24 24"
+      data-testid="FaceSvg"
       aria-hidden="true"
-      focusable="false">
+      focusable="false"
+    >
       <path d="M 12 2 C 6.48 2 2 6.48 2 12 C 2 17.52 6.48 22 12 22 C 17.52 22 22 17.52 22 12 C 22 6.48 17.52 2 12 2 Z M 12 20 C 7.59 20 4 16.41 4 12 L 4 11.97 C 6.31 11.75 4.112 9.608 5.577 8.196 C 6.094 7.697 8.453 7.785 9.24 8 C 11.753 8.418 12.676 8.377 14.77 8 C 15.696 7.851 17.871 7.747 18.455 8.434 C 19.757 9.968 17.65 11.74 20 11.96 L 20 11.99 C 20 16.41 16.41 20 12 20 Z"></path>
       <circle cx="9" cy="13" r="1.25"></circle>
       <circle cx="15" cy="13" r="1.25"></circle>

--- a/src/landing/home-stats/infographics/network-circle.jsx
+++ b/src/landing/home-stats/infographics/network-circle.jsx
@@ -1,7 +1,4 @@
 // @ts-check
-
-/// <reference path="../../../types.d.ts" />
-
 import React from 'react';
 
 import { FaceIcon } from './face-icon';
@@ -21,53 +18,64 @@ import { localise } from '../../../localisation';
 export function NetworkCircle({
   activeAccounts = 21000000,
   deletedAccounts = 1000000,
-  percentNumberBlocked1 = 48.40,
+  percentNumberBlocked1 = 48.4,
   percentNumberBlocking1 = 42.53,
-  loading }) {
+  loading,
+}) {
   return (
-    <div className='network-circle'>
-      <div className='network-circle-circle'>
+    <div className="network-circle">
+      <div className="network-circle-circle">
         <SvgCircles
           circles={[
             {
               percent: percentNumberBlocking1,
-              caption: localise('blocking someone', {uk: 'блокують когось'}),
-              className: 'arc-percentNumberBlocking1'
+              caption: localise('blocking someone', { uk: 'блокують когось' }),
+              className: 'arc-percentNumberBlocking1',
             },
             {
               percent: percentNumberBlocked1,
-              caption: localise('blocked at least by one', { uk: 'заблоковані хоч одним' }),
+              caption: localise('blocked at least by one', {
+                uk: 'заблоковані хоч одним',
+              }),
               className: 'arc-percentNumberBlocked1',
-              outside: true
-            }
+              outside: true,
+            },
           ]}
         />
 
-        <div className='network-crowd network-active-crowd'>
-          <div className='network-crowd-active-count-container'>
-            <div className='network-crowd-active-count'>{activeAccounts.toLocaleString()}</div>
-            <div className='network-crowd-active-label'>{localise('active accounts', { uk: 'активних акаунтів' })}</div>
+        <div className="network-crowd network-active-crowd">
+          <div className="network-crowd-active-count-container">
+            <div className="network-crowd-active-count">
+              {activeAccounts.toLocaleString()}
+            </div>
+            <div className="network-crowd-active-label">
+              {localise('active accounts', { uk: 'активних акаунтів' })}
+            </div>
           </div>
           {/* 9 faces */}
-          <FaceIcon className='crowd-icon' />
-          <FaceIcon className='crowd-icon' />
-          <FaceIcon className='crowd-icon' />
+          <FaceIcon className="crowd-icon" />
+          <FaceIcon className="crowd-icon" />
+          <FaceIcon className="crowd-icon" />
           <br />
-          <FaceIcon className='crowd-icon' />
-          <FaceIcon className='crowd-icon' />
-          <FaceIcon className='crowd-icon' />
-          <FaceIcon className='crowd-icon' />
+          <FaceIcon className="crowd-icon" />
+          <FaceIcon className="crowd-icon" />
+          <FaceIcon className="crowd-icon" />
+          <FaceIcon className="crowd-icon" />
           <br />
-          <FaceIcon className='crowd-icon' />
-          <FaceIcon className='crowd-icon' />
+          <FaceIcon className="crowd-icon" />
+          <FaceIcon className="crowd-icon" />
         </div>
-        <div className='network-crowd network-deleted-crowd'>
-          <div className='network-crowd-deleted-count-container'>
-            <div className='network-crowd-deleted-count'>{deletedAccounts.toLocaleString()}</div>
-            <div className='network-crowd-deleted-label'>{localise('deleted', { uk: 'закрито' })}</div>
+        <div className="network-crowd network-deleted-crowd">
+          <div className="network-crowd-deleted-count-container">
+            <div className="network-crowd-deleted-count">
+              {deletedAccounts.toLocaleString()}
+            </div>
+            <div className="network-crowd-deleted-label">
+              {localise('deleted', { uk: 'закрито' })}
+            </div>
           </div>
 
-          <FaceIcon removed className='crowd-icon crowd-icon-deleted' />
+          <FaceIcon removed className="crowd-icon crowd-icon-deleted" />
         </div>
       </div>
     </div>
@@ -87,87 +95,104 @@ export function NetworkCircle({
  * }} _
  */
 function SvgCircles({ className, circles, ...rest }) {
-
   const expandSize = 19;
   const outsidePathPadding = -15;
   const insidePathPadding = +3;
 
+  /** @type {Array<React.JSX.Element>} */
   const defPaths = [];
 
-  const circleElements = circles.map(({ percent, caption, className, fill, outside }, index) => {
-  
-    const startPath = `M ${200 - expandSize},100`;
-    const valueRad = Math.PI * 2 * (100 - percent) / 100;
-    const valueX = Math.cos(valueRad) * (100 - expandSize) + 100;
-    const valueY = Math.sin(valueRad) * (100 - expandSize) + 100;
-    const largeArc = percent > 50 ? 1 : 0;
+  const circleElements = circles.map(
+    ({ percent, caption, className, fill, outside }, index) => {
+      const startPath = `M ${200 - expandSize},100`;
+      const valueRad = (Math.PI * 2 * (100 - percent)) / 100;
+      const valueX = Math.cos(valueRad) * (100 - expandSize) + 100;
+      const valueY = Math.sin(valueRad) * (100 - expandSize) + 100;
+      const largeArc = percent > 50 ? 1 : 0;
 
-    const arcPath =
-      `A ${100 - expandSize}, ${100 - expandSize} 0 ${largeArc},0 ${valueX.toFixed(4)},${valueY.toFixed(4)}`;
+      const arcPath = `A ${100 - expandSize}, ${
+        100 - expandSize
+      } 0 ${largeArc},0 ${valueX.toFixed(4)},${valueY.toFixed(4)}`;
 
-    const expandDirection = outside ? expandSize : -expandSize;
+      const expandDirection = outside ? expandSize : -expandSize;
 
-    const expandX = Math.cos(valueRad) * (100 - expandSize + expandDirection) + 100;
-    const expandY = Math.sin(valueRad) * (100 - expandSize + expandDirection) + 100;
+      const expandX =
+        Math.cos(valueRad) * (100 - expandSize + expandDirection) + 100;
+      const expandY =
+        Math.sin(valueRad) * (100 - expandSize + expandDirection) + 100;
 
-    const closeArcPath =
-      `L ${expandX.toFixed(4)},${expandY.toFixed(4)} ` +
-      `A ${100 - expandSize + expandDirection},${100 - expandSize + expandDirection} 0 ${largeArc},1 ${200 - expandSize + expandDirection},100`;
+      const closeArcPath =
+        `L ${expandX.toFixed(4)},${expandY.toFixed(4)} ` +
+        `A ${100 - expandSize + expandDirection},${
+          100 - expandSize + expandDirection
+        } 0 ${largeArc},1 ${200 - expandSize + expandDirection},100`;
 
-    const wholePath =
-      startPath + ' ' + arcPath + ' ' + closeArcPath + ' Z';
+      const wholePath = startPath + ' ' + arcPath + ' ' + closeArcPath + ' Z';
 
-    const padding = outside ? outsidePathPadding : insidePathPadding;
+      const padding = outside ? outsidePathPadding : insidePathPadding;
 
-    const textArcX = Math.cos(valueRad + 0.03) * (100 - expandSize + expandDirection + padding) + 100;
-    const textArcY = Math.sin(valueRad + 0.04) * (100 - expandSize + expandDirection + padding) + 100;
-    const textArc =
-      `M ${textArcX.toFixed(4)},${textArcY.toFixed(4)} ` +
-      `A ${100 - expandSize + expandDirection + padding}, ${100 - expandSize + expandDirection + padding} 0 ${largeArc},1 ${200 - expandSize + expandDirection + padding},100`;
+      const textArcX =
+        Math.cos(valueRad + 0.03) *
+          (100 - expandSize + expandDirection + padding) +
+        100;
+      const textArcY =
+        Math.sin(valueRad + 0.04) *
+          (100 - expandSize + expandDirection + padding) +
+        100;
+      const textArc =
+        `M ${textArcX.toFixed(4)},${textArcY.toFixed(4)} ` +
+        `A ${100 - expandSize + expandDirection + padding}, ${
+          100 - expandSize + expandDirection + padding
+        } 0 ${largeArc},1 ${200 - expandSize + expandDirection + padding},100`;
 
-    const textArcPathId = 'path' + index;
-    defPaths.push(<path key={index} id={textArcPathId} d={textArc} />);
-    const percentText = percent.toLocaleString() + '%';
+      const textArcPathId = 'path' + index;
+      defPaths.push(<path key={index} id={textArcPathId} d={textArc} />);
+      const percentText = percent.toLocaleString() + '%';
 
-    return (
-      <React.Fragment key={index}>
-        <path className={className} fill={fill} d={wholePath} />
-        <text className={className + '-text'}>
-          <textPath
-            className='arc-text arc-text-percent'
-            href={'#' + textArcPathId}
-            xlinkHref={'#' + textArcPathId}>
-            {percentText}
-          </textPath>
-          <textPath
-            className='arc-text arc-text-caption'
-            href={'#' + textArcPathId}
-            xlinkHref={'#' + textArcPathId}
-            startOffset={(percentText.length * 0.93) + 'em'}>
-            {caption}
-          </textPath>
-        </text>
-      </React.Fragment>
-    ); // startOffset='50%' textAnchor='middle'
-  });
+      return (
+        <React.Fragment key={index}>
+          <path className={className} fill={fill} d={wholePath} />
+          <text className={className + '-text'}>
+            <textPath
+              className="arc-text arc-text-percent"
+              href={'#' + textArcPathId}
+              xlinkHref={'#' + textArcPathId}
+            >
+              {percentText}
+            </textPath>
+            <textPath
+              className="arc-text arc-text-caption"
+              href={'#' + textArcPathId}
+              xlinkHref={'#' + textArcPathId}
+              startOffset={percentText.length * 0.93 + 'em'}
+            >
+              {caption}
+            </textPath>
+          </text>
+        </React.Fragment>
+      ); // startOffset='50%' textAnchor='middle'
+    }
+  );
 
   return (
     <svg
       className={'arc-text-svg ' + (className || '')}
       xmlns="http://www.w3.org/2000/svg"
-      xmlnsXlink="http://www.w3.org/1999/xlink" 
+      xmlnsXlink="http://www.w3.org/1999/xlink"
       {...rest}
-      viewBox='0 0 200 200'
-      aria-hidden='true'
-      focusable='false'>
-      <defs>
-        {defPaths}
-      </defs>
+      viewBox="0 0 200 200"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <defs>{defPaths}</defs>
       {circleElements}
       <circle
-        fill='none'
-        className='arc-circle'
-        cx='100' cy='100' r={100-expandSize} />
+        fill="none"
+        className="arc-circle"
+        cx="100"
+        cy="100"
+        r={100 - expandSize}
+      />
     </svg>
   );
 }

--- a/src/landing/home-stats/infographics/top-blocked.jsx
+++ b/src/landing/home-stats/infographics/top-blocked.jsx
@@ -7,20 +7,23 @@ import { localise } from '../../../localisation';
 
 /**
  * @param {{
- *  blocked: BlockList | undefined,
- *  blocked24: BlockList | undefined,
+ *  blocked: BlockList | null,
+ *  blocked24: BlockList | null,
  *  limit?: number
  * }} _
  */
 export function TopBlocked({ blocked, blocked24, limit }) {
   return (
     <TopList
-      className='top-blocked'
+      className="top-blocked"
       header={(list) =>
-        localise(`Top ${list.length || ''} Blocked`,
-          { uk: `Топ ${list.length || ''} заблокованих` })}
+        localise(`Top ${list.length || ''} Blocked`, {
+          uk: `Топ ${list.length || ''} заблокованих`,
+        })
+      }
       list={blocked}
       list24={blocked24}
-      limit={limit} />
+      limit={limit}
+    />
   );
 }

--- a/src/landing/home-stats/infographics/top-blockers.jsx
+++ b/src/landing/home-stats/infographics/top-blockers.jsx
@@ -7,20 +7,23 @@ import { localise } from '../../../localisation';
 
 /**
  * @param {{
- *  blockers: BlockList | undefined,
- *  blockers24: BlockList | undefined,
+ *  blockers: BlockList | null,
+ *  blockers24: BlockList | null,
  *  limit?: number
  * }} _
  */
 export function TopBlockers({ blockers, blockers24, limit }) {
   return (
     <TopList
-      className='top-blockers'
+      className="top-blockers"
       header={(list) =>
-        localise(`Top ${list.length || ''} Blockers`,
-          { uk: `Топ ${list.length || ''} блок-берсеркерів` })}
+        localise(`Top ${list.length || ''} Blockers`, {
+          uk: `Топ ${list.length || ''} блок-берсеркерів`,
+        })
+      }
       list={blockers}
       list24={blockers24}
-      limit={limit} />
+      limit={limit}
+    />
   );
 }

--- a/src/landing/home-stats/infographics/top-list.jsx
+++ b/src/landing/home-stats/infographics/top-list.jsx
@@ -1,12 +1,10 @@
 // @ts-check
 
-/// <reference path="../../../types.d.ts" />
-
 import React, { useState } from 'react';
 
 import { AccountShortEntry } from '../../../common-components/account-short-entry';
 
-import './top-list.css'
+import './top-list.css';
 import { Switch } from '@mui/material';
 import { localise } from '../../../localisation';
 
@@ -16,54 +14,72 @@ const DEFAULT_LIMIT = 5;
  * @param {{
  *  className?: string,
  *  header?: React.ReactNode | ((list: DashboardBlockListEntry[]) => React.ReactNode),
- *  list: BlockList | undefined,
- *  list24: BlockList | undefined,
+ *  list: BlockList | null,
+ *  list24: BlockList | null,
  *  limit?: number
  * }} _
  */
 export function TopList({
   className,
   header,
-  list, list24,
-  limit = DEFAULT_LIMIT }) {
-  const [expanded, setExpanded] = useState(/** @type {boolean | undefined } */(undefined));
-  const [see24, setSee24] = useState(/** @type {boolean | undefined } */(undefined));
+  list,
+  list24,
+  limit = DEFAULT_LIMIT,
+}) {
+  const [expanded, setExpanded] = useState(
+    /** @type {boolean | undefined } */ (undefined)
+  );
+  const [see24, setSee24] = useState(
+    /** @type {boolean | undefined } */ (undefined)
+  );
 
   const useList = getDashboardList(see24 ? list24 : list);
 
-  const blockedSlice =
-    !useList ? [] :
-      expanded ? useList :
-        useList?.slice(0, limit);
+  const blockedSlice = !useList
+    ? []
+    : expanded
+    ? useList
+    : useList?.slice(0, limit);
 
   return (
     <div className={'top-list ' + (className || '')}>
-      <h2 className='top-list-header'>
-        {
-          typeof header === 'function' ? header(blockedSlice) :
-            header || defaultHeader(blockedSlice)
-        }
-        <span className='top-list-24h-toggle-container'>
-          <Switch value={!!see24} onChange={() => setSee24(!see24)} size='small' /> <br />
-          <span className='top-list-24h-toggle-label'
-            onClick={() => setSee24(!see24)}>
+      <h2 className="top-list-header">
+        {typeof header === 'function'
+          ? header(blockedSlice)
+          : header || defaultHeader(blockedSlice)}
+        <span className="top-list-24h-toggle-container">
+          <Switch
+            value={!!see24}
+            onChange={() => setSee24(!see24)}
+            size="small"
+          />{' '}
+          <br />
+          <span
+            className="top-list-24h-toggle-label"
+            onClick={() => setSee24(!see24)}
+          >
             {localise('last 24h', { uk: 'за 24г' })}
           </span>
         </span>
       </h2>
-      <div className='top-list-entries'>
-        {
-          !useList ? localise('Loading...', { uk: 'Зачекайте...' }) :
-            blockedSlice.map((blockEntry, index) =>
-              <BlockListEntry key={blockEntry.did + '-' + (className || '') + '-' + index} entry={blockEntry} />)
-        }
-        {
-          useList && useList.length > limit ?
-            <div className='top-list-more' onClick={() => setExpanded(!expanded)}>
-              <span>{localise(`...see top-${useList.length}`, { uk: `...топ-${useList.length}` })}</span>
-            </div> :
-            undefined
-        }
+      <div className="top-list-entries">
+        {!useList
+          ? localise('Loading...', { uk: 'Зачекайте...' })
+          : blockedSlice.map((blockEntry, index) => (
+              <BlockListEntry
+                key={blockEntry.did + '-' + (className || '') + '-' + index}
+                entry={blockEntry}
+              />
+            ))}
+        {useList && useList.length > limit ? (
+          <div className="top-list-more" onClick={() => setExpanded(!expanded)}>
+            <span>
+              {localise(`...see top-${useList.length}`, {
+                uk: `...топ-${useList.length}`,
+              })}
+            </span>
+          </div>
+        ) : undefined}
       </div>
     </div>
   );
@@ -73,22 +89,19 @@ export function TopList({
  * @param {DashboardBlockListEntry[]} list
  */
 function defaultHeader(list) {
-  return (
-    <>
-    Top {list?.length || undefined} Blocked
-    </>
-  );
+  return <>Top {list?.length || undefined} Blocked</>;
 }
 
 /** @param {{ entry: DashboardBlockListEntry }} _ */
 function BlockListEntry({ entry }) {
   return (
-    <div className='top-list-entry'>
+    <div className="top-list-entry">
       <AccountShortEntry
         account={entry.did}
-        contentClassName='top-list-entry-content'
-        accountTooltipPanel >
-        <span className='top-list-entry-count'>
+        contentClassName="top-list-entry-content"
+        accountTooltipPanel
+      >
+        <span className="top-list-entry-count">
           {entry.count.toLocaleString()}
         </span>
       </AccountShortEntry>
@@ -97,20 +110,22 @@ function BlockListEntry({ entry }) {
 }
 
 /**
- * @param {Array | Object | null} listData
+ * @param {BlockList | null} listData
  * @returns {DashboardBlockListEntry[]}
  */
-  function getDashboardList(listData) {
-      /** @type {DashboardBlockListEntry[]} */
-      const dashboardBlockList = []
+function getDashboardList(listData) {
+  /** @type {DashboardBlockListEntry[]} */
+  const dashboardBlockList = [];
 
-      if(listData) {
-        Object.keys(listData).forEach((key) => {
-          let allValues = listData[key]
-          allValues['did'] = key
-          dashboardBlockList.push(allValues)
-        })
-        dashboardBlockList.sort((a, b) => b.count - a.count)
-      }
-      return dashboardBlockList
+  if (listData) {
+    Object.keys(listData).forEach((key) => {
+      let allValues = listData[key];
+      dashboardBlockList.push({
+        ...allValues,
+        did: key,
+      });
+    });
+    dashboardBlockList.sort((a, b) => b.count - a.count);
   }
+  return dashboardBlockList;
+}

--- a/src/landing/home-stats/infographics/top-list.jsx
+++ b/src/landing/home-stats/infographics/top-list.jsx
@@ -114,10 +114,10 @@ function BlockListEntry({ entry }) {
  * @returns {DashboardBlockListEntry[]}
  */
 function getDashboardList(listData) {
-  /** @type {DashboardBlockListEntry[]} */
-  const dashboardBlockList = [];
-
-  if (listData && typeof listData === 'object' && !Array.isArray(listData)) {
+  // TODO remove this first case after prod migrates top blocked format
+  if (listData && !Array.isArray(listData)) {
+    /** @type {DashboardBlockListEntry[]} */
+    const dashboardBlockList = [];
     Object.keys(listData).forEach((key) => {
       let allValues = listData[key];
       dashboardBlockList.push({
@@ -126,6 +126,9 @@ function getDashboardList(listData) {
       });
     });
     dashboardBlockList.sort((a, b) => b.count - a.count);
+    return dashboardBlockList;
+  } else if (listData && Array.isArray(listData)) {
+    return listData;
   }
-  return dashboardBlockList;
+  return [];
 }

--- a/src/landing/search-autocomplete/search-entry-display.jsx
+++ b/src/landing/search-autocomplete/search-entry-display.jsx
@@ -1,75 +1,41 @@
 // @ts-check
-// <reference path="../api.d.ts" />
 
-import React from 'react';
-
-import { isPromise, resolveHandleOrDID } from '../../api';
+import { useResolveHandleOrDid } from '../../api';
 import { SearchEntryLayout } from './search-entry-layout';
 
 /**
- * @extends {React.Component<{ entry: SearchMatch }, { }>}
+ * @param {{ entry: SearchMatch }} props
  */
-export class SearchEntryDisplay extends React.Component {
-  /** @type {string} */
-  shortDID;
+export function SearchEntryDisplay(props) {
+  const request = useResolveHandleOrDid(props.entry.shortDID);
 
-  /** @type {Promise | undefined} */
-  promise;
-
-  /** @type {AccountInfo | undefined} */
-  account;
-
-  /** @type {Error | undefined} */
-  error;
-
-  render() {
-    if (this.shortDID !== this.props.entry.shortDID) {
-      this.shortDID = this.props.entry.shortDID;
-      const accountOrPromise = resolveHandleOrDID(this.shortDID);
-
-      if (isPromise(accountOrPromise)) {
-        this.promise = accountOrPromise;
-        this.account = undefined;
-        this.error = undefined;
-        accountOrPromise.then(
-          account => {
-            this.promise = undefined;
-            this.account = account;
-            this.error = undefined;
-            this.setState(account);
-          },
-          error => {
-            this.promise = undefined;
-            this.account = undefined;
-            this.error = error;
-            this.setState(error);
-          });
-      } else {
-        this.promise = undefined;
-        this.account = accountOrPromise;
-        this.error = undefined;
-      }
-    }
-
-    if (this.error) {
-      return <ResolveFailure {...this.props} error={this.error} />;
-    } else if (this.account) {
-      return <ResolveSuccess {...this.props} account={this.account} />;
-    } else {
-      return <ResolvingMatch {...this.props} />;
-    }
+  if (request.isLoading) {
+    return <ResolvingMatch entry={props.entry} />;
   }
+  if (request.error || !request.data) {
+    return <ResolveFailure entry={props.entry} error={request.error} />;
+  }
+  return <ResolveSuccess {...props} account={request.data} />;
 }
 
-/** @param {{ entry: SearchMatch, error: Error }} _ */
+/** @param {{ entry: SearchMatch, error: Error | null }} _ */
 function ResolveFailure({ error, ...rest }) {
   return (
-    <SearchEntryLayout {...rest} className='resolve-failure-item'>
+    <SearchEntryLayout {...rest} className="resolve-failure-item">
       <>
-        {error?.constructor?.name ? <span className='error-constructor-name'>{error.constructor.name}</span> : undefined}
-        {error?.message ? <span className='error-message'>{error.message}</span> : undefined}
-        {error?.stack && error.stack !== error.message ?
-          <span className='error-stack'>{error.stack.replace(error.message || '', '')}</span> : undefined}
+        {error?.constructor?.name ? (
+          <span className="error-constructor-name">
+            {error.constructor.name}
+          </span>
+        ) : undefined}
+        {error?.message ? (
+          <span className="error-message">{error.message}</span>
+        ) : undefined}
+        {error?.stack && error.stack !== error.message ? (
+          <span className="error-stack">
+            {error.stack.replace(error.message || '', '')}
+          </span>
+        ) : undefined}
       </>
     </SearchEntryLayout>
   );
@@ -79,14 +45,15 @@ function ResolveFailure({ error, ...rest }) {
  * @param {{ entry: SearchMatch }} _
  */
 function ResolvingMatch({ ...rest }) {
-  return (
-    <SearchEntryLayout {...rest} />
-  );
+  return <SearchEntryLayout {...rest} />;
 }
 
 /** @param {{ entry: SearchMatch, account: AccountInfo, className?: string }} _ */
 function ResolveSuccess({ className, ...rest }) {
   return (
-    <SearchEntryLayout {...rest} className={'resolve-success-item ' + (className || '')} />
+    <SearchEntryLayout
+      {...rest}
+      className={'resolve-success-item ' + (className || '')}
+    />
   );
 }

--- a/src/localisation/index.js
+++ b/src/localisation/index.js
@@ -14,7 +14,7 @@ export function localise(english, languageMap) {
  */
 export function localiseNumberSuffix(word, num) {
   return localise(localiseNumberSuffixEnglish(word, num), {
-    uk: localiseNumberSuffixUkrainian(word, num)
+    uk: localiseNumberSuffixUkrainian(word, num),
   });
 }
 
@@ -30,10 +30,11 @@ function localiseNumberSuffixEnglish(word, num) {
   return word + 's';
 }
 
+/** @type {Record<string, string | undefined>} */
 const enWordPluralisations = {
   fish: 'fish',
   sheep: 'sheep',
-  child: 'children'
+  child: 'children',
 };
 
 /**
@@ -47,6 +48,7 @@ function localiseNumberSuffixUkrainian(word, num) {
   return word + 'и';
 }
 
+/** @type {Record<string, string | undefined>} */
 const ukWordPluralisations = {
-  'списку': 'списків',
+  списку: 'списків',
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -80,13 +80,13 @@ interface BlockStats {
 }
 
 interface FunFacts {
-  blocked: BlockList;
-  blockers: BlockList;
+  blocked: BlockList | null;
+  blockers: BlockList | null;
 }
 
 interface FunnerFacts {
-  blocked24: BlockList;
-  blockers24: BlockList;
+  blocked24: BlockList | null;
+  blockers24: BlockList | null;
 }
 
 type DashboardStats = {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -108,12 +108,15 @@ type StatsEndpointResp<Data> =
   | { timeLeft: string };
 
 interface BlockData {
+  did: string;
   count: number;
 }
 
-interface BlockList {
-  [did: string]: BlockData;
-}
+type BlockList =
+  | Array<BlockData>
+  | /* old format, to be deleted after migration*/ {
+      [did: string]: { count: number };
+    };
 
 interface DashboardBlockListEntry {
   count: number;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,10 @@
 /// <reference types="@atproto/api" />
 /// <reference types="vite/client" />
 
+declare module 'punycode2/to-ascii' {
+  export default function toASCII(input: string): string;
+}
+
 type AccountInfo = {
   shortDID: string;
   shortHandle: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,11 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowJs": true,
+    "strict": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "noEmit": true
   },
-  "files": ["src/app.jsx", "src/logo-images.js", "src/types.d.ts"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
Enabling strict mode will help catch way more really simple bugs like unexpected null/undefined values.

Almost everything being changed is just in the type def comments and standard reformatting via `prettier`, but there are a couple of substantial changes worth testing:

- upgraded our atproto client package to the latest
- rewrote some of the components in the front page search slightly

IMO a lot of this typing work would be a bit easier if we were actually using typescript file sources instead of js + jsdoc comments and I might push for another migration in that direction in the future. For now we're still well covered, though.