### PR TITLE
Add a global error handler

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -12,11 +12,6 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from './api/query-client';
 import { ErrorBoundary } from './common-components/error-boundary';
 
-async function homeLoader() {
-  const { Home } = await import('./landing/home');
-  return { Component: Home };
-}
-
 import './app.css';
 
 function showApp() {
@@ -33,12 +28,18 @@ function showApp() {
       {
         ErrorBoundary,
         children: [
-          { index: true, lazy: homeLoader },
+          {
+            index: true,
+            async lazy() {
+              const { Home } = await import('./landing/home');
+              return { Component: Home };
+            },
+          },
           { path: 'index.html', element: <Navigate to="/" replace /> },
           { path: 'stable/*', element: <Navigate to="/" replace /> },
           {
             path: ':handle/:tab?',
-            lazy: async () => {
+            async lazy() {
               const { AccountLayout } = await import('./detail-panels');
               return {
                 Component: AccountLayout,

--- a/src/common-components/error-boundary.jsx
+++ b/src/common-components/error-boundary.jsx
@@ -1,0 +1,79 @@
+// @ts-check
+
+import { useRouteError } from 'react-router-dom';
+
+import {
+  Box,
+  Card,
+  CardHeader,
+  CardContent,
+  CardActions,
+  Button,
+} from '@mui/material';
+import { useState } from 'react';
+
+/**
+ * @param {*} error
+ * @returns {string}
+ */
+function getMessage(error) {
+  if (!error) return '';
+  if ('message' in error) {
+    return error.message.toString();
+  }
+  if (typeof error.toString === 'function') {
+    return error.toString();
+  }
+  return '';
+}
+
+const REFRESHED_FOR_ERROR = 'refreshed_for_error';
+
+function refreshForNextRelease() {
+  sessionStorage.setItem(REFRESHED_FOR_ERROR, '1');
+  reloadPage();
+}
+
+function reloadPage() {
+  location.reload();
+}
+
+export function ErrorBoundary() {
+  const [justRefreshedForNextRelease] = useState(() => {
+    // this helps prevent infinite reload loops from the automatic refresh behavior added below
+    // first we check for our session storage item and save its existence in memory
+    let value = !!sessionStorage.getItem(REFRESHED_FOR_ERROR);
+    // then remove it after a short delay, so future reloads will not continue to see it
+    setTimeout(() => sessionStorage.removeItem(REFRESHED_FOR_ERROR), 10_000);
+    return value;
+  });
+  const error = useRouteError();
+  const message = getMessage(error);
+  let advice = 'Hopefully all will be fine if you reload the page.';
+  if (message.startsWith('Failed to fetch dynamically imported module: ')) {
+    if (justRefreshedForNextRelease) {
+      advice =
+        "Unfortunately it's seems serious and reloading the page probably won't solve anything.";
+    } else {
+      refreshForNextRelease();
+    }
+  }
+  return (
+    <Box sx={{ maxWidth: 550, margin: 2, alignSelf: 'center' }}>
+      <Card variant="outlined">
+        <CardHeader title="Error caught 🌜" />
+        <CardContent>
+          <p>An error just happened. {advice}</p>
+          {message && (
+            <p>
+              Error message: <code>{message}</code>
+            </p>
+          )}
+        </CardContent>
+        <CardActions>
+          <Button onClick={reloadPage}>Reload</Button>
+        </CardActions>
+      </Card>
+    </Box>
+  );
+}

--- a/src/detail-panels/account-header/account-header.jsx
+++ b/src/detail-panels/account-header/account-header.jsx
@@ -28,7 +28,6 @@ export function AccountHeader({
   const [isCopied, setIsCopied] = useState(false);
   const [handleHistoryExpanded, setHandleHistoryExpanded] = useState(false);
   const resolved = useAccountResolver();
-  console.log(resolved.data)
   const handleHistoryQuery = useHandleHistory(resolved.data?.shortDID);
   const handleHistory = handleHistoryQuery.data?.handle_history;
  

--- a/src/detail-panels/index.js
+++ b/src/detail-panels/index.js
@@ -1,1 +1,1 @@
-export { AccountLayout as default } from './layout';
+export { AccountLayout } from './layout';

--- a/src/landing/home.jsx
+++ b/src/landing/home.jsx
@@ -10,7 +10,7 @@ import { Logo } from './logo';
 import { HomeStats } from './home-stats';
 import { About } from './about';
 
-export default function Home() {
+export function Home() {
   const [searchText, setSearchText] = React.useState('');
   const [aboutOpen, setAboutOpen] = React.useState(false);
   const navigate = useNavigate();


### PR DESCRIPTION
When any ordinary error happens users will see:
![image](https://github.com/user-attachments/assets/e248264a-fa3a-4528-a6b8-1d5604dd4163)

However, when we encounter the specific error raised in #244 the page will automatically reload, possibly without them even noticing. If that error then reoccurs immediately, rather than going into an infinite reload loop, they will see this instead:

![image](https://github.com/user-attachments/assets/b513c9cc-aa10-4d09-85ef-22e22c65de6a)

fixes #244 