### PR TITLE
add option to override api endpoint

### DIFF
--- a/src/api/core.js
+++ b/src/api/core.js
@@ -25,12 +25,25 @@ let baseStagingURL = 'https://staging.api.clearsky.services/';
 
 export const v1APIPrefix = '/api/v1/anon/';
 
+const params = new URLSearchParams(location.search);
+const apiOverride = params.get('api');
+
+function getApiBase() {
+  switch (apiOverride) {
+    case 'staging':
+      return baseStagingURL;
+    case 'prod':
+      return baseURL;
+    default:
+      return location.hostname !== 'clearsky.app' ? baseStagingURL : baseURL;
+  }
+}
+
 /**
  * @param {string} apiURL
  */
 export function unwrapClearskyURL(apiURL) {
-  const runStaging = location.hostname !== 'clearsky.app';
-  const useBaseURL = runStaging ? baseStagingURL : baseURL;
+  const useBaseURL = getApiBase();
 
   return useBaseURL + apiURL.replace(/^\//, '');
 }


### PR DESCRIPTION
You can now force the UI to use either `staging` or `prod` API endpoints by adding a query param when the page loads:

`https://clearsky.app/?api=staging` will load prod UI but use the staging api endpoint

`https://dev.clearskyui.pages.dev/?api=prod` will load the staging UI and use prod API endpoint