### PR TITLE
Update packages, readme, and copyright year

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1760,16 +1760,16 @@
       "license": "MIT"
     },
     "node_modules/ag-grid-community": {
-      "version": "31.0.3",
-      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.0.3.tgz",
-      "integrity": "sha512-k81YmLaOQOab9BavYD+Pw2smZSl6TXOJqj9hRuf70XQl3EknOHCGcra7joJxZRJLMKE/HdR+u33TNyX4TCuWfg=="
+      "version": "31.3.4",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.3.4.tgz",
+      "integrity": "sha512-jOxQO86C6eLnk1GdP24HB6aqaouFzMWizgfUwNY5MnetiWzz9ZaAmOGSnW/XBvdjXvC5Fpk3gSbvVKKQ7h9kBw=="
     },
     "node_modules/ag-grid-react": {
-      "version": "31.0.3",
-      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-31.0.3.tgz",
-      "integrity": "sha512-CE4Z5Rdb0H3MFBhmge9854AyDvI4DoG7ZoUJRFB1p2pu5ANVe6tv7cwEI/ugHemEXRRP6s5uvW+ndv0Q6x1/+Q==",
+      "version": "31.3.4",
+      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-31.3.4.tgz",
+      "integrity": "sha512-WmPASHRFGSTxCMRStWG5bRtln0Ugsdqbb3+Y8sEyGHeLw4hXqfpqie3lT9kqCOl7wPWUjCpwmFdXzRnWPmyyeg==",
       "dependencies": {
-        "ag-grid-community": "~31.0.3",
+        "ag-grid-community": "31.3.4",
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -14,22 +14,22 @@ Install dependencies with `npm install`
 
 `npm run build && npm run preview` will serve a production-type build locally
 
-## Deployment:
+## Deployment
 
 Deploys are automatically handled by Cloudflare Pages
 
-## Code Contributions:
+## Code Contributions
 
-We appreciate and welcome any code contributions. To make a PR you must first fork the repo and then make a PR from the 
+We appreciate and welcome any code contributions. To make a PR you must first fork the repo and then make a PR from the
 branch you created.
 
 Rules:
 
 - Make a comment on the ticket you would like to work on so we can assign it to you and to prevent duplicate efforts
 - Check for existing issues before making a new one
-- We may close an issue or PR without much feedback 
+- We may close an issue or PR without much feedback
 - Stay away from PRs that:
-  - Refactor large parts of the codebase 
-  - Add entirely new features without prior discussion 
-  - Change the tooling or frameworks used without prior discussion 
+  - Refactor large parts of the codebase
+  - Add entirely new features without prior discussion
+  - Change the tooling or frameworks used without prior discussion
   - Introduce new unnecessary dependencies

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -91,7 +91,7 @@ function showApp() {
             />
           </React.Suspense>
           <div className="bluethernal-llc-watermark">
-            © 2024 Bluethernal LLC
+            © 2025 Bluethernal LLC
           </div>
         </QueryClientProvider>
       </ThemeProvider>


### PR DESCRIPTION
- Updates readme based on linter
  - This isn't necessary, but I like to use a very particular markdown linter (it hates spaces at the end of a line, amongst other things).
- Updates packages to resolve a high vuln
  - Ran `npm update` for 2 specific packages, not on the entire package library. Hence the smaller package-lock update.
  - `npm audit` will now show 0 vulns (constant vigilance is needed, of course)
- Copyright tag change from 2024 to 2025
  - We in the future now woot woot!