### PR TITLE
Adding front end display of list potential spam flagging.

### DIFF
--- a/src/detail-panels/lists/list-view.jsx
+++ b/src/detail-panels/lists/list-view.jsx
@@ -1,7 +1,9 @@
 // @ts-check
 
-import { IconButton, Tooltip } from '@mui/material';
+import { useState } from 'react';
+import { IconButton, Tooltip, tooltipClasses } from '@mui/material';
 import InfoIcon from '@mui/icons-material/Info';
+import ClickAwayListener from '@mui/material/ClickAwayListener';
 import { AccountShortEntry } from '../../common-components/account-short-entry';
 import { FormatTimestamp } from '../../common-components/format-timestamp';
 
@@ -33,6 +35,16 @@ export function ListView({ className, list }) {
  */
 function ListViewEntry({ className, entry }) {
 
+  const [open, setOpen] = useState(false);
+
+  const handleTooltipClose = () => {
+    setOpen(false);
+  };
+
+  const handleTooltipOpen = () => {
+    setOpen(true);
+  };
+
   const opacity = entry.spam? 0.4 : 1;
 
   return (
@@ -55,11 +67,31 @@ function ListViewEntry({ className, entry }) {
           {entry.name}
           </a>
           {entry.spam && (
-            <Tooltip title={`Flagged as spam. Source: ${entry.source || 'unknown'}`}>
-              <IconButton>
-                <InfoIcon />
-              </IconButton>
-            </Tooltip>
+            <ClickAwayListener onClickAway={handleTooltipClose}>
+              <Tooltip 
+                title={`Flagged as spam. Source: ${entry.source || 'unknown'}`}
+                onClose={handleTooltipClose}
+                open={open}
+                disableFocusListener
+                disableHoverListener
+                disableTouchListener
+                slotProps={{
+                  popper: {
+                    disablePortal: true,
+                    sx: {
+                      [`&.${tooltipClasses.popper}[data-popper-placement*="bottom"] .${tooltipClasses.tooltip}`]:
+                        {
+                          marginTop: '0px',
+                        },
+                    },
+                  },
+                }}
+              >
+                <IconButton onClick={handleTooltipOpen}>
+                  <InfoIcon />
+                </IconButton>
+              </Tooltip>
+            </ClickAwayListener>
           )}
         </span>
       </div>

--- a/src/detail-panels/lists/list-view.jsx
+++ b/src/detail-panels/lists/list-view.jsx
@@ -1,5 +1,7 @@
 // @ts-check
 
+import { IconButton, Tooltip } from '@mui/material';
+import InfoIcon from '@mui/icons-material/Info';
 import { AccountShortEntry } from '../../common-components/account-short-entry';
 import { FormatTimestamp } from '../../common-components/format-timestamp';
 
@@ -30,9 +32,12 @@ export function ListView({ className, list }) {
  * }} _
  */
 function ListViewEntry({ className, entry }) {
+
+  const opacity = entry.spam? 0.4 : 1;
+
   return (
     <li className={'lists-entry ' + (className || '')}>
-      <div className='row'>
+      <div className='row' style={{opacity}}>
         <AccountShortEntry
           className='list-owner'
           withDisplayName
@@ -43,14 +48,22 @@ function ListViewEntry({ className, entry }) {
           noTooltip
           className='list-add-date' />
       </div>
-      <div className='row'>
+      {/* <div className='row'  > */}
+      <div>
         <span className='list-name'>
-          <a href={entry.url} target='__blank'>
+          <a href={entry.url} target='__blank' style={{opacity}}>
           {entry.name}
           </a>
+          {entry.spam && (
+            <Tooltip title={`Flagged as spam. Source: ${entry.source || 'unknown'}`}>
+              <IconButton>
+                <InfoIcon />
+              </IconButton>
+            </Tooltip>
+          )}
         </span>
       </div>
-      {entry.description && <div className='row'>
+      {entry.description && <div className='row' style={{opacity}}>
         <span className='list-description'>
           {' ' + entry.description}
         </span>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -144,4 +144,6 @@ type AccountListEntry = {
   name: string;
   status: boolean;
   url: string;
+  spam: boolean | null;
+  source: string | null;
 };


### PR DESCRIPTION
Adds in potential spam flag and source for list entries. Resolves #276 

- [x] Typecheck runs successfully.
- [x] Local npm build runs successfully.

## Change Details

- Increases opacity for any list flagged as potential spam
  - Tried to do this on the parent code only but kept botching the override. Feel free to cleanup if you want. I'll knock the JS/TS dust off eventually.
- Adds tooltip to potential spam list entries to flag source
  - Activate by clicking on the info icon for these potential spam list entries.
- Modifies types to reflect new endpoint fields. Allows for null.
- Removes row className for the title of the list entry.
  - I left this commented out code in the PR. Removing the className helps with a whitespace/horizontal scroll issue that I'm currently experiencing on mobile. Please test this on your end to make sure this hasn't botched anything else up on the list view.