### PR TITLE
Fix scroll reset issue on tab switch for content container

### DIFF
--- a/src/detail-panels/history/search-header.css
+++ b/src/detail-panels/history/search-header.css
@@ -10,7 +10,7 @@
 
 @media (max-width: 800px) {
   .history-header {
-    top: 5em;
+    /* top: 5em; */
     padding-top: 0;
   }
 }

--- a/src/detail-panels/layout.css
+++ b/src/detail-panels/layout.css
@@ -222,6 +222,8 @@
     grid-column: 1 / 2;
     grid-row: 3 / 4;
     border-left: none;
+    max-height: 80em;
+    overflow-y: scroll;
   }
 
   .account-tabs-handles {

--- a/src/detail-panels/layout.jsx
+++ b/src/detail-panels/layout.jsx
@@ -83,7 +83,7 @@ export function AccountLayoutCore({
           onTabSelected={(selectedTab) => onSetSelectedTab(selectedTab)}
         />
 
-        <div className="account-tabs-content">
+        <div key={selectedTab} className="account-tabs-content">
           {accountTabs.map((tab) => {
             if (tab === selectedTab)
               return (


### PR DESCRIPTION
Ensures the content scrolls to the top when switching tabs.
Added logic to reset scroll position using key prop.