### PR TITLE
correctly pass deps to useEffect in Visible component

### DIFF
--- a/src/api/packs.js
+++ b/src/api/packs.js
@@ -1,32 +1,30 @@
-import { fetchClearskyApi } from './core'; 
+import { fetchClearskyApi } from './core';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
-import { shortenDID, unwrapShortHandle } from '.';
+import { unwrapShortHandle } from '.';
 import { useResolveHandleOrDid } from './resolve-handle-or-did';
 const PAGE_SIZE = 100;
 
 /**
  * @param {string | undefined} handleOrDID
  */
-export function usePacksCreated(handleOrDID){ 
-  
-    const profileQuery = useResolveHandleOrDid(handleOrDID);
-    const shortHandle = profileQuery.data?.shortHandle;
-    return useInfiniteQuery({
-        enabled: !!shortHandle,
-        queryKey: ['starter-packs', shortHandle],
-        // @ts-expect-error shortHandle won't really be undefined because the query will be disabled
-        queryFn: ({ pageParam }) => getPacksCreated(shortHandle, pageParam),
-        initialPageParam: 1,
-        getNextPageParam: (lastPage) => lastPage.nextPage,
-      });
+export function usePacksCreated(handleOrDID) {
+  const profileQuery = useResolveHandleOrDid(handleOrDID);
+  const shortHandle = profileQuery.data?.shortHandle;
+  return useInfiniteQuery({
+    enabled: !!shortHandle,
+    queryKey: ['starter-packs', shortHandle],
+    queryFn: ({ pageParam }) => getPacksCreated(shortHandle, pageParam),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => lastPage.nextPage,
+  });
 }
 
 /**
  * @param {string | undefined} handleOrDID
  */
-export function usePacksCreatedTotal(handleOrDID){  
+export function usePacksCreatedTotal(handleOrDID) {
   const profileQuery = useResolveHandleOrDid(handleOrDID);
-    const shortHandle = profileQuery.data?.shortHandle;
+  const shortHandle = profileQuery.data?.shortHandle;
   return useQuery({
     enabled: !!shortHandle,
     queryKey: ['starter-packs-total', shortHandle],
@@ -37,46 +35,48 @@ export function usePacksCreatedTotal(handleOrDID){
 /**
  * @param {string | undefined} handleOrDID
  */
-export function usePacksPopulated(handleOrDID){ 
-  const profileQuery = useResolveHandleOrDid(handleOrDID);
-    const shortHandle = profileQuery.data?.shortHandle;
- 
-  return useInfiniteQuery({
-      enabled: !!shortHandle,
-      queryKey: ['single-starter-pack', shortHandle],
-      queryFn: ({ pageParam }) => getPacksPopulated(shortHandle, pageParam),
-      initialPageParam: 1,
-      getNextPageParam: (lastPage) => lastPage.nextPage,
-    });
-} 
-
-/**
- * @param {string | undefined} handleOrDID 
- */
-export  function usePacksPopulatedTotal(handleOrDID){  
+export function usePacksPopulated(handleOrDID) {
   const profileQuery = useResolveHandleOrDid(handleOrDID);
   const shortHandle = profileQuery.data?.shortHandle;
-    return useQuery({
-        enabled: !!shortHandle,
-        queryKey: ['starter-pack-total', shortHandle],
-        // @ts-expect-error shortHandle won't really be undefined because the query will be disabled
-        queryFn: () => getPacksPopulatedTotal(shortHandle),
-      }); 
+
+  return useInfiniteQuery({
+    enabled: !!shortHandle,
+    queryKey: ['single-starter-pack', shortHandle],
+    queryFn: ({ pageParam }) => getPacksPopulated(shortHandle, pageParam),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => lastPage.nextPage,
+  });
+}
+
+/**
+ * @param {string | undefined} handleOrDID
+ */
+export function usePacksPopulatedTotal(handleOrDID) {
+  const profileQuery = useResolveHandleOrDid(handleOrDID);
+  const shortHandle = profileQuery.data?.shortHandle;
+  return useQuery({
+    enabled: !!shortHandle,
+    queryKey: ['starter-pack-total', shortHandle],
+    queryFn: () => getPacksPopulatedTotal(shortHandle),
+  });
 }
 
 /**
  * @param {string} shortHandle
  * @param {number} currentPage
  * @returns {Promise<{
-*    starter_packs: Array<PackListEntry>,
-*    nextPage: number | null
-* }>}
-*/
-async function getPacksPopulated (shortHandle, currentPage){
+ *    starter_packs: Array<PackListEntry>,
+ *    nextPage: number | null
+ * }>}
+ */
+async function getPacksPopulated(shortHandle, currentPage) {
   // in PACK
-  const URL = 'single-starter-pack/' + unwrapShortHandle(shortHandle) ; 
-  // @type PackList 
-  const re = await fetchClearskyApi('v1', URL);  
+  const URL =
+    'single-starter-pack/' +
+    unwrapShortHandle(shortHandle) +
+    (currentPage === 1 ? '' : '/' + currentPage);
+  // @type PackList
+  const re = await fetchClearskyApi('v1', URL);
 
   const starter_packs = re.data?.starter_packs || [];
 
@@ -87,55 +87,57 @@ async function getPacksPopulated (shortHandle, currentPage){
     return date2 - date1;
   });
   return {
-      starter_packs, 
-      nextPage: starter_packs.length >= PAGE_SIZE ? currentPage + 1 : null,
+    starter_packs,
+    nextPage: starter_packs.length >= PAGE_SIZE ? currentPage + 1 : null,
   };
-  
 }
 
 /**
- * @param {string} shortHandle 
+ * @param {string} shortHandle
  */
-async function getPacksPopulatedTotal(shortHandle){ 
+async function getPacksPopulatedTotal(shortHandle) {
   const URL = 'single-starter-pack/total/' + unwrapShortHandle(shortHandle);
-  
-    /** @type {{ data: { count: number; pages: number } }} */
-    const re = await fetchClearskyApi('v1', URL);
-    return re.data;
+
+  /** @type {{ data: { count: number; pages: number } }} */
+  const re = await fetchClearskyApi('v1', URL);
+  return re.data;
 }
 
 /**
  * @param {string} shortHandle
  * @param {number} currentPage
  * @returns {Promise<{
-*    starter_packs: Array<PackListEntry>,
-*    nextPage: number | null
-* }>}
-*/
-async function getPacksCreated(shortHandle, currentPage=1){
-    // packs I started  
-    const URL ='starter-packs/' + unwrapShortHandle(shortHandle)  + (currentPage === 1 ? '' : '/' + currentPage); 
- 
-    const re = (await fetchClearskyApi('v1', URL)); 
-    const starter_packs = re.data?.starter_packs || [];
+ *    starter_packs: Array<PackListEntry>,
+ *    nextPage: number | null
+ * }>}
+ */
+async function getPacksCreated(shortHandle, currentPage = 1) {
+  // packs I started
+  const URL =
+    'starter-packs/' +
+    unwrapShortHandle(shortHandle) +
+    (currentPage === 1 ? '' : '/' + currentPage);
+
+  const re = await fetchClearskyApi('v1', URL);
+  const starter_packs = re.data?.starter_packs || [];
 
   // Sort by date
   starter_packs.sort((entry1, entry2) => {
     const date1 = new Date(entry1.date_added).getTime();
     const date2 = new Date(entry2.date_added).getTime();
     return date2 - date1;
-  }); 
-    return {
-      starter_packs, 
-      nextPage: starter_packs.length >= PAGE_SIZE ? currentPage + 1 : null};
- 
+  });
+  return {
+    starter_packs,
+    nextPage: starter_packs.length >= PAGE_SIZE ? currentPage + 1 : null,
+  };
 }
 
 /**
  * @param {string} shortHandle
  */
-async function getPacksCreatedTotal(shortHandle){ 
-  const URL = 'starter-packs/total/' + unwrapShortHandle(shortHandle); 
+async function getPacksCreatedTotal(shortHandle) {
+  const URL = 'starter-packs/total/' + unwrapShortHandle(shortHandle);
 
   /** @type {{ data: { count: number; pages: number } }} */
   const re = await fetchClearskyApi('v1', URL);

--- a/src/common-components/visible.jsx
+++ b/src/common-components/visible.jsx
@@ -1,6 +1,6 @@
 // @ts-check
 import React from 'react';
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 
 /** @typedef {{
  *  Component?: React.ElementType,
@@ -25,7 +25,7 @@ export function Visible({
   children,
   ...rest
 }) {
-  let [visible, setVisible] = useState(false);
+  let visibleRef = useRef(false);
   const ref = useRef(null);
 
   useEffect(() => {
@@ -35,8 +35,8 @@ export function Visible({
 
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting !== visible) {
-          setVisible(entry.isIntersecting);
+        if (entry.isIntersecting !== visibleRef.current) {
+          visibleRef.current = entry.isIntersecting;
           if (entry.isIntersecting) onVisible?.();
           else onObscured?.();
         }
@@ -49,8 +49,7 @@ export function Visible({
 
     observer.observe(ref.current);
     return () => observer.disconnect();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ref.current]);
+  }, [onObscured, onVisible, rootMargin, threshold]);
 
   return (
     <Component ref={ref} {...rest}>


### PR DESCRIPTION
the Visible component was previously breaking several rules of how you should use react at once, and managing to work as intended with the combination of bad things it was doing. after adding the linter it identified the bad things. I previously fixed one and ignored the other: https://github.com/ClearskyApp06/ClearskyUI/commit/566951d97871bfced8134f45fe0e0fd07e9b8106#diff-66b34b935fda5fd20aada030042ddee176aa4854cac57b9ee88b8b8ec2fb053e

This reduced it to only breaking one rule, and ended up breaking how the component worked as a result.

fixes #333 