### PR TITLE
TypeError in autocomplete

### DIFF
--- a/src/api/search/search-handle.js
+++ b/src/api/search/search-handle.js
@@ -23,7 +23,7 @@ export async function searchHandle(searchText) {
   if (cachedSearches[searchText]) return cachedSearches[searchText];
 
   const directResolvesOrPromises = searchText
-    .split(/\s+/)
+    .split(/[\s.]+/)
     .filter((word) => !!word)
     .map(async (word) => {
       const postLink = breakPostURL(word) || breakFeedUri(word);


### PR DESCRIPTION
Fixes #325 

This PR fixes a TypeError that occurred during autocomplete when the input included dot-separated values (eg:priya.bsky) 
When entering inputs like this into the search bar, the app throws a TypeError and fails to fetch results. This happens because the input isn't being split correctly the period (.) is treated as part of the word rather than a delimiter.
So to fix this issue replacing split(/\s+/) with .split(/[\s.]+/) ensure that both whitespace and dot separates the inputs into ["priya", "bsky", "social"] The issue happened because inputs like priya.bsky were treated as full website URLs, which caused the fetch to fail. This fix updates the splitting logic to break down those inputs correctly

![Screenshot (152)](https://github.com/user-attachments/assets/457ab791-1be4-40a9-a1ae-ed6db03586f5)
![Screenshot (154)](https://github.com/user-attachments/assets/6a3bba26-dc60-4dc0-a97a-92c48bfe2cad)
![Screenshot (156)](https://github.com/user-attachments/assets/a87db3f9-e60d-497b-ba5a-13425e6194f0)
