### PR TITLE
feat: Add financial contribution modal (Issue #340)

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -11,6 +11,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 
 import { queryClient } from './api/query-client';
 import { ErrorBoundary } from './common-components/error-boundary';
+import { SupportBanner } from './common-components/support-banner';
 import { getDefaultComponent } from './utils/get-default';
 import { profileChildRoutesPromise } from './detail-panels/tabs';
 import './app.css';
@@ -85,6 +86,7 @@ async function showApp() {
               future={{ v7_startTransition: true }}
             />
           </React.Suspense>
+          <SupportBanner />
           <div className="bluethernal-llc-watermark">
             © 2025 Bluethernal Inc
           </div>

--- a/src/common-components/support-banner.jsx
+++ b/src/common-components/support-banner.jsx
@@ -8,11 +8,12 @@ import {
   Button,
   Typography,
   Box,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 
 export function SupportBanner() {
   const [open, setOpen] = React.useState(() => {
-    // Show only if it hasn't been dismissed this session
     return !sessionStorage.getItem('supportBannerDismissed');
   });
 
@@ -20,6 +21,9 @@ export function SupportBanner() {
     setOpen(false);
     sessionStorage.setItem('supportBannerDismissed', 'true');
   };
+
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
 
   return (
     <Dialog
@@ -29,13 +33,21 @@ export function SupportBanner() {
       maxWidth="xs"
       fullWidth
     >
-      <DialogTitle id="support-dialog-title" align="center">
-        <Typography variant="h4">Thank You</Typography>
+      <DialogTitle
+        id="support-dialog-title"
+        align="center"
+        variant={fullScreen ? 'h5' : 'h4'}
+      >
+        Thank You
       </DialogTitle>
 
       <DialogContent>
-        <Typography variant="body1" align="center" gutterBottom>
-          If you&apos;ve found ClearSky helpful, please consider supporting us.
+        <Typography
+          variant={fullScreen ? 'body2' : 'body1'}
+          align="center"
+          gutterBottom
+        >
+          If you&apos;ve found Clearsky helpful, please consider supporting us.
           Your contribution helps keep the project running and improving for
           everyone.
         </Typography>
@@ -57,10 +69,11 @@ export function SupportBanner() {
               display: 'flex',
               backgroundColor: '#0095FF',
               width: '100%',
+              height: '100%',
               alignItems: 'center',
-              gap: 2,
-              paddingY: 1,
-              paddingX: 2,
+              gap: fullScreen ? 1.5 : 2,
+              paddingY: fullScreen ? 0.8 : 1,
+              paddingX: fullScreen ? 1.5 : 2,
               borderRadius: 2,
               textTransform: 'none',
               justifyContent: 'start',
@@ -71,9 +84,12 @@ export function SupportBanner() {
             <img
               src="https://uxwing.com/wp-content/themes/uxwing/download/brands-and-social-media/ko-fi-icon.png"
               alt="Ko-fi"
-              height="50"
+              height={fullScreen ? 35 : 50}
             />
-            <Typography variant="h6" component="span">
+            <Typography
+              variant={fullScreen ? 'subtitle1' : 'h6'}
+              component="span"
+            >
               Ko-fi
             </Typography>
           </Button>
@@ -88,10 +104,11 @@ export function SupportBanner() {
               display: 'flex',
               backgroundColor: '#1764fdff',
               width: '100%',
+              height: '100%',
               alignItems: 'center',
-              gap: 2,
-              paddingY: 1,
-              paddingX: 2,
+              gap: fullScreen ? 1.5 : 2,
+              paddingY: fullScreen ? 0.8 : 1,
+              paddingX: fullScreen ? 1.5 : 2,
               borderRadius: 2,
               textTransform: 'none',
               justifyContent: 'start',
@@ -102,9 +119,12 @@ export function SupportBanner() {
             <img
               src="https://avatars.githubusercontent.com/u/13403593?s=200&v=4"
               alt="OpenCollective"
-              height="50"
+              height={fullScreen ? 35 : 50}
             />
-            <Typography variant="h6" component="span">
+            <Typography
+              variant={fullScreen ? 'subtitle1' : 'h6'}
+              component="span"
+            >
               Open Collective
             </Typography>
           </Button>

--- a/src/common-components/support-banner.jsx
+++ b/src/common-components/support-banner.jsx
@@ -11,10 +11,15 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material';
+import { useFeatureFlag } from '../api/featureFlags';
 
 export function SupportBanner() {
+  const showDonationPopup = useFeatureFlag('donation-popup');
+
   const [open, setOpen] = React.useState(() => {
-    return !sessionStorage.getItem('supportBannerDismissed');
+    return showDonationPopup
+      ? !sessionStorage.getItem('supportBannerDismissed')
+      : false;
   });
 
   const handleClose = () => {

--- a/src/common-components/support-banner.jsx
+++ b/src/common-components/support-banner.jsx
@@ -1,0 +1,121 @@
+// @ts-check
+import * as React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Box,
+} from '@mui/material';
+
+export function SupportBanner() {
+  const [open, setOpen] = React.useState(() => {
+    // Show only if it hasn't been dismissed this session
+    return !sessionStorage.getItem('supportBannerDismissed');
+  });
+
+  const handleClose = () => {
+    setOpen(false);
+    sessionStorage.setItem('supportBannerDismissed', 'true');
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      aria-labelledby="support-dialog-title"
+      maxWidth="xs"
+      fullWidth
+    >
+      <DialogTitle id="support-dialog-title" align="center">
+        <Typography variant="h4">Thank You</Typography>
+      </DialogTitle>
+
+      <DialogContent>
+        <Typography variant="body1" align="center" gutterBottom>
+          If you&apos;ve found ClearSky helpful, please consider supporting us.
+          Your contribution helps keep the project running and improving for
+          everyone.
+        </Typography>
+
+        <Box
+          display="flex"
+          flexDirection="column"
+          gap={2}
+          mt={3}
+          textAlign="left"
+        >
+          {/* Ko-fi Button */}
+          <Button
+            variant="contained"
+            href="https://ko-fi.com/clearskyapp"
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{
+              display: 'flex',
+              backgroundColor: '#0095FF',
+              width: '100%',
+              alignItems: 'center',
+              gap: 2,
+              paddingY: 1,
+              paddingX: 2,
+              borderRadius: 2,
+              textTransform: 'none',
+              justifyContent: 'start',
+              transition: 'transform 0.2s',
+              '&:hover': { transform: 'scale(1.03)' },
+            }}
+          >
+            <img
+              src="https://uxwing.com/wp-content/themes/uxwing/download/brands-and-social-media/ko-fi-icon.png"
+              alt="Ko-fi"
+              height="50"
+            />
+            <Typography variant="h6" component="span">
+              Ko-fi
+            </Typography>
+          </Button>
+
+          {/* OpenCollective Button */}
+          <Button
+            variant="contained"
+            href="https://opencollective.com/clearsky"
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{
+              display: 'flex',
+              backgroundColor: '#1764fdff',
+              width: '100%',
+              alignItems: 'center',
+              gap: 2,
+              paddingY: 1,
+              paddingX: 2,
+              borderRadius: 2,
+              textTransform: 'none',
+              justifyContent: 'start',
+              transition: 'transform 0.2s',
+              '&:hover': { transform: 'scale(1.03)' },
+            }}
+          >
+            <img
+              src="https://avatars.githubusercontent.com/u/13403593?s=200&v=4"
+              alt="OpenCollective"
+              height="50"
+            />
+            <Typography variant="h6" component="span">
+              Open Collective
+            </Typography>
+          </Button>
+        </Box>
+      </DialogContent>
+
+      <DialogActions sx={{ justifyContent: 'center' }}>
+        <Button onClick={handleClose} color="inherit">
+          <Typography variant="button">Dismiss</Typography>
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
# Support Banner for Financial Contributions (Issue #340)

This PR implements a modal banner encouraging users to support ClearSky via Ko-fi or OpenCollective, addressing Issue #340.

## Changes include
- Updated modal header to **"Thank You"** with a concise contribution message.  
- Added buttons for Ko-fi and OpenCollective, including logos and a responsive layout for desktop and mobile.  
- Session-based dismissal: the modal only appears once per browser session.  
- Added feature flag support (`donation-popup`) to control banner visibility.  

This enhancement provides a subtle, visually appealing prompt for user contributions while maintaining accessibility and responsiveness across devices.
