### PR TITLE
Integrate Google AdSense and FirstPartyAd Components

### DIFF
--- a/src/api/core.js
+++ b/src/api/core.js
@@ -52,11 +52,12 @@ export function unwrapClearskyURL(apiURL) {
  *
  * @param {"v1"} apiVer
  * @param {string} apiPath
+ * @param {RequestInit} [options] optional fetch options
  * @returns
  */
-export function fetchClearskyApi(apiVer, apiPath) {
+export function fetchClearskyApi(apiVer, apiPath, options) {
   const apiUrl = unwrapClearskyURL(v1APIPrefix + apiPath);
-  return fetch(apiUrl).then((x) => x.json());
+  return fetch(apiUrl, options).then((x) => x.json());
 }
 
 /**

--- a/src/api/useAdTracking.js
+++ b/src/api/useAdTracking.js
@@ -38,16 +38,15 @@ export function useGetAdByPlacement(placementId) {
  * @param {ClickParams} params
  */
 async function sendClickThruRaw({ adId, placementId }) {
-  const query = new URLSearchParams({
-    'ad-id': adId,
-    'placement-id': placementId,
-  });
-
-  const json = await fetchClearskyApi('v1', `ads/click-thru?${query}`, {
+  const json = await fetchClearskyApi('v1', `ads/click-thru`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
+    body: JSON.stringify({
+      'ad-id': adId,
+      'placement-id': placementId,
+    }),
   });
 
   return json.data;

--- a/src/api/useAdTracking.js
+++ b/src/api/useAdTracking.js
@@ -25,7 +25,8 @@ export function useGetAdByPlacement(placementId) {
     queryKey: ['ad-by-placement', placementId],
     queryFn: async () => {
       const json = await fetchClearskyApi('v1', `ads/get-ad/${placementId}`);
-      return json.data[0];
+      const response = json.data[0].ad_content_url ? json.data[0] : null;
+      return response;
     },
   });
 }

--- a/src/api/useAdTracking.js
+++ b/src/api/useAdTracking.js
@@ -1,0 +1,66 @@
+// @ts-check
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { fetchClearskyApi } from './core';
+
+/**
+ * Fetch all ads
+ */
+export function useGetAllAds() {
+  return useQuery({
+    queryKey: ['all-ads'],
+    queryFn: async () => {
+      const json = await fetchClearskyApi('v1', 'ads/get-ads');
+      return json.data;
+    },
+  });
+}
+
+/**
+ * Fetch a specific ad by placement identifier
+ * @param {string} placementId
+ */
+export function useGetAdByPlacement(placementId) {
+  return useQuery({
+    enabled: !!placementId,
+    queryKey: ['ad-by-placement', placementId],
+    queryFn: async () => {
+      const json = await fetchClearskyApi('v1', `ads/get-ad/${placementId}`);
+      return json.data[0];
+    },
+  });
+}
+/**
+ * @typedef {{ adId: string, placementId: string }} ClickParams
+ */
+
+/**
+ * Track a click through for an ad
+ * @param {ClickParams} params
+ */
+async function sendClickThruRaw({ adId, placementId }) {
+  const query = new URLSearchParams({
+    'ad-id': adId,
+    'placement-id': placementId,
+  });
+
+  const json = await fetchClearskyApi('v1', `ads/click-thru?${query}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  return json.data;
+}
+
+/**
+ * Hook to track clicks
+ */
+export function useSendClickThru() {
+  return useMutation(
+    /** @type {import('@tanstack/react-query').UseMutationOptions<any, unknown, ClickParams>} */
+    ({
+      mutationFn: (params) => sendClickThruRaw(params),
+    })
+  );
+}

--- a/src/common-components/block-lists-view.jsx
+++ b/src/common-components/block-lists-view.jsx
@@ -21,9 +21,13 @@ const AD_FREQUENCY = 35;
 export function BlockListsView({ className, list, handle }) {
   return (
     <ul className={'lists-as-list-view ' + (className || '')}>
-      {(list || []).map((entry, i) => {
-        if (i % AD_FREQUENCY === 0 && i > 0) {
-          return (
+      {(list || []).flatMap((entry, i) => {
+        const elements = [
+          <BlockListsViewEntry key={entry.date_added ?? i} entry={entry} handle={handle} />
+        ];
+
+        if (i > 0 && i % AD_FREQUENCY === 0) {
+          elements.push(
             <GoogleAdSlot
               key={`ad-${i}-blocked-list-9114105783`}
               slot="9114105783"
@@ -32,9 +36,12 @@ export function BlockListsView({ className, list, handle }) {
             />
           );
         }
-        return <BlockListsViewEntry key={i} entry={entry} handle={handle} />;
+
+        return elements;
       })}
+
       <GoogleAdSlot
+        key="ad-end-blocked-list-9114105783"
         slot="9114105783"
         format="fluid"
         layoutKey="-fb+5w+4e-db+86"
@@ -42,6 +49,7 @@ export function BlockListsView({ className, list, handle }) {
     </ul>
   );
 }
+
 
 /**
  * @param {{

--- a/src/common-components/block-lists-view.jsx
+++ b/src/common-components/block-lists-view.jsx
@@ -9,6 +9,8 @@ import { ConditionalAnchor } from './conditional-anchor';
 import { useResolveHandleOrDid } from '../api';
 import { GoogleAdSlot } from './google-ad-slot';
 
+const AD_FREQUENCY = 35;
+
 /**
  * @param {{
  *  className?: string,
@@ -20,7 +22,7 @@ export function BlockListsView({ className, list, handle }) {
   return (
     <ul className={'lists-as-list-view ' + (className || '')}>
       {(list || []).map((entry, i) => {
-        if (i % 10 === 0 && i > 0) {
+        if (i % AD_FREQUENCY === 0 && i > 0) {
           return (
             <GoogleAdSlot
               key={`ad-${i}-blocked-list-9114105783`}

--- a/src/common-components/block-lists-view.jsx
+++ b/src/common-components/block-lists-view.jsx
@@ -50,7 +50,6 @@ export function BlockListsView({ className, list, handle }) {
   );
 }
 
-
 /**
  * @param {{
  *  className?: string,

--- a/src/common-components/block-lists-view.jsx
+++ b/src/common-components/block-lists-view.jsx
@@ -7,6 +7,7 @@ import './block-lists-view.css';
 import { Link } from 'react-router-dom';
 import { ConditionalAnchor } from './conditional-anchor';
 import { useResolveHandleOrDid } from '../api';
+import { GoogleAdSlot } from './google-ad-slot';
 
 /**
  * @param {{
@@ -18,9 +19,24 @@ import { useResolveHandleOrDid } from '../api';
 export function BlockListsView({ className, list, handle }) {
   return (
     <ul className={'lists-as-list-view ' + (className || '')}>
-      {(list || []).map((entry, i) => (
-        <BlockListsViewEntry key={i} entry={entry} handle={handle} />
-      ))}
+      {(list || []).map((entry, i) => {
+        if (i % 10 === 0 && i > 0) {
+          return (
+            <GoogleAdSlot
+              key={`ad-${i}-blocked-list-9114105783`}
+              slot="9114105783"
+              format="fluid"
+              layoutKey="-fb+5w+4e-db+86"
+            />
+          );
+        }
+        return <BlockListsViewEntry key={i} entry={entry} handle={handle} />;
+      })}
+      <GoogleAdSlot
+        slot="9114105783"
+        format="fluid"
+        layoutKey="-fb+5w+4e-db+86"
+      />
     </ul>
   );
 }

--- a/src/common-components/first-party-ad.jsx
+++ b/src/common-components/first-party-ad.jsx
@@ -1,0 +1,140 @@
+// @ts-check
+import React, { useRef } from 'react';
+import PropTypes from 'prop-types';
+import { Box, Typography } from '@mui/material';
+import { useSendClickThru, useGetAdByPlacement } from '../api/useAdTracking';
+
+/**
+ * FirstPartyAd component
+ * @param {{
+ *   placementId: string,
+ *   size: 'leaderboard' | 'largeLeaderboard' | 'mediumRectangle' | 'wideSkyscraper' | 'banner' | 'responsive' | 'responsiveBanner',
+ * }} props
+ */
+export function FirstPartyAd({ placementId, size }) {
+  const iframeRef = useRef(null);
+  const sendClickThru = useSendClickThru();
+  const { data: adData, isLoading } = useGetAdByPlacement(placementId);
+
+  const styleMap = {
+    leaderboard: { width: 728, height: 90 },
+    largeLeaderboard: { width: 970, height: 90 },
+    mediumRectangle: { width: 300, height: 250 },
+    wideSkyscraper: { width: 160, height: 600 },
+    banner: { width: 320, height: 50 },
+    responsiveBanner: {
+      width: '100%',
+      maxWidth: 728,
+      height: 'auto',
+    },
+    responsive: {
+      width: '100%',
+      height: 'auto',
+    },
+  };
+
+  const style = styleMap[size] || { width: '100%', height: 100 };
+
+  const handleClick = () => {
+    if (!adData) return;
+
+    if (adData.id && adData.placement_id) {
+      sendClickThru.mutate({
+        adId: adData.id,
+        placementId: adData.placement_id,
+      });
+    }
+    if (adData.target_url) {
+      window.open(adData.target_url, '_blank', 'noopener,noreferrer');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Box
+        sx={{
+          ...style,
+          bgcolor: 'grey.100',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Typography variant="caption">Loading ad...</Typography>
+      </Box>
+    );
+  }
+
+  if (!adData) {
+    return (
+      <Box
+        sx={{
+          ...style,
+          border: '1px dashed',
+          borderColor: 'primary.main',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <Typography variant="caption">
+          No ad available for this placement
+        </Typography>
+      </Box>
+    );
+  }
+
+  const isHtmlCreative =
+    adData.ad_content_url &&
+    (adData.ad_content_url.endsWith('.html') ||
+      adData.ad_content_url.includes('<html>'));
+
+  return (
+    <Box
+      sx={{
+        ...style,
+        bgcolor: 'grey.100',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        p: 1,
+        overflow: 'hidden',
+        cursor: 'pointer',
+      }}
+      onClick={handleClick}
+    >
+      {isHtmlCreative ? (
+        <iframe
+          ref={iframeRef}
+          src={adData.ad_content_url}
+          title={`Ad placement ${adData.id}`}
+          style={{ width: '100%', height: '100%', border: 'none' }}
+        />
+      ) : (
+        <img
+          src={adData.ad_content_url}
+          alt={`Ad placement ${adData.id}`}
+          style={{
+            maxWidth: '100%',
+            height: '100%',
+            maxHeight: '100%',
+            objectFit: 'contain',
+          }}
+        />
+      )}
+    </Box>
+  );
+}
+
+FirstPartyAd.propTypes = {
+  placementId: PropTypes.string.isRequired,
+  size: PropTypes.oneOf([
+    'leaderboard',
+    'largeLeaderboard',
+    'mediumRectangle',
+    'wideSkyscraper',
+    'banner',
+    'responsive',
+    'responsiveBanner',
+  ]).isRequired,
+};

--- a/src/common-components/first-party-ad.jsx
+++ b/src/common-components/first-party-ad.jsx
@@ -3,6 +3,7 @@ import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Typography } from '@mui/material';
 import { useSendClickThru, useGetAdByPlacement } from '../api/useAdTracking';
+import { useFeatureFlag } from '../api/featureFlags';
 
 /**
  * FirstPartyAd component
@@ -15,6 +16,8 @@ export function FirstPartyAd({ placementId, size }) {
   const iframeRef = useRef(null);
   const sendClickThru = useSendClickThru();
   const { data: adData, isLoading } = useGetAdByPlacement(placementId);
+  // const showFirstPartyAds = useFeatureFlag('first-party-ads');
+  const showFirstPartyAds = true;
 
   const styleMap = {
     leaderboard: { width: 728, height: 90 },
@@ -25,7 +28,7 @@ export function FirstPartyAd({ placementId, size }) {
     responsiveBanner: {
       width: '100%',
       maxWidth: 728,
-      height: 'auto',
+      height: 100,
     },
     responsive: {
       width: '100%',
@@ -48,6 +51,10 @@ export function FirstPartyAd({ placementId, size }) {
       window.open(adData.target_url, '_blank', 'noopener,noreferrer');
     }
   };
+
+  if (!showFirstPartyAds) {
+    return null;
+  }
 
   if (isLoading) {
     return (
@@ -93,7 +100,6 @@ export function FirstPartyAd({ placementId, size }) {
     <Box
       sx={{
         ...style,
-        bgcolor: 'grey.100',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',

--- a/src/common-components/first-party-ad.jsx
+++ b/src/common-components/first-party-ad.jsx
@@ -1,7 +1,7 @@
 // @ts-check
 import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
-import { Box, Typography } from '@mui/material';
+import { Box } from '@mui/material';
 import { useSendClickThru, useGetAdByPlacement } from '../api/useAdTracking';
 import { useFeatureFlag } from '../api/featureFlags';
 
@@ -16,8 +16,7 @@ export function FirstPartyAd({ placementId, size }) {
   const iframeRef = useRef(null);
   const sendClickThru = useSendClickThru();
   const { data: adData, isLoading } = useGetAdByPlacement(placementId);
-  // const showFirstPartyAds = useFeatureFlag('first-party-ads');
-  const showFirstPartyAds = true;
+  const showFirstPartyAds = useFeatureFlag('first-party-ads');
 
   const styleMap = {
     leaderboard: { width: 728, height: 90 },
@@ -27,8 +26,8 @@ export function FirstPartyAd({ placementId, size }) {
     banner: { width: 320, height: 50 },
     responsiveBanner: {
       width: '100%',
-      maxWidth: 728,
-      height: 100,
+      maxWidth: 720,
+      maxHeight: 100,
     },
     responsive: {
       width: '100%',
@@ -52,44 +51,10 @@ export function FirstPartyAd({ placementId, size }) {
     }
   };
 
-  if (!showFirstPartyAds) {
+  if (!showFirstPartyAds || isLoading || !adData) {
     return null;
   }
 
-  if (isLoading) {
-    return (
-      <Box
-        sx={{
-          ...style,
-          bgcolor: 'grey.100',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Typography variant="caption">Loading ad...</Typography>
-      </Box>
-    );
-  }
-
-  if (!adData) {
-    return (
-      <Box
-        sx={{
-          ...style,
-          border: '1px dashed',
-          borderColor: 'primary.main',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Typography variant="caption">
-          No ad available for this placement
-        </Typography>
-      </Box>
-    );
-  }
 
   const isHtmlCreative =
     adData.ad_content_url &&

--- a/src/common-components/first-party-ad.jsx
+++ b/src/common-components/first-party-ad.jsx
@@ -23,7 +23,11 @@ export function FirstPartyAd({ placementId, size }) {
     largeLeaderboard: { width: 970, height: 90 },
     mediumRectangle: { width: 300, height: 250 },
     wideSkyscraper: { width: 160, height: 600 },
-    banner: { width: 320, height: 50 },
+    banner: {
+      width: "100%",
+      maxWidth: 320,
+      height: 40
+    },
     responsiveBanner: {
       width: '100%',
       maxWidth: 720,
@@ -68,7 +72,6 @@ export function FirstPartyAd({ placementId, size }) {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        p: 1,
         overflow: 'hidden',
         cursor: 'pointer',
       }}

--- a/src/common-components/google-ad-slot.jsx
+++ b/src/common-components/google-ad-slot.jsx
@@ -44,11 +44,13 @@ export function GoogleAdSlot({ slot, format = 'auto', layoutKey, style = {} }) {
     return (
       <div
         style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
           background: '#eee',
           border: '1px dashed #ccc',
           color: '#888',
-          textAlign: 'center',
-          lineHeight: style.height ? `${style.height}px` : '150px',
+          height: '50px',
           ...style,
         }}
       >
@@ -61,7 +63,7 @@ export function GoogleAdSlot({ slot, format = 'auto', layoutKey, style = {} }) {
   return (
     <ins
       className="adsbygoogle"
-      style={{ display: 'block', ...style }}
+      style={{ display: 'block', height: '50px', ...style }}
       data-ad-client="ca-pub-3810029603871683"
       data-ad-slot={slot}
       data-ad-format={format}

--- a/src/common-components/google-ad-slot.jsx
+++ b/src/common-components/google-ad-slot.jsx
@@ -1,8 +1,12 @@
+// @ts-check
 import { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
+import { useFeatureFlag } from '../api/featureFlags';
 
 /**
  * Google AdSense ad slot component
+ * Shows a placeholder in development and real ads in production
+ *
  * @param {Object} props
  * @param {string} props.slot - The AdSense ad slot ID.
  * @param {'auto' | 'fluid'} [props.format='auto'] - The ad format type.
@@ -13,17 +17,45 @@ export function GoogleAdSlot({ slot, format = 'auto', layoutKey, style = {} }) {
   const adRef = useRef(null);
   const pushedRef = useRef(false); // track if adsbygoogle.push was called
 
+  const isDev = import.meta.env.DEV || import.meta.env.VITE_IS_DEV;
+  // const showGoolgleAds = useFeatureFlag('google-ads');
+  const showGoolgleAds = true;
+
   useEffect(() => {
-    if (!adRef.current || pushedRef.current) return;
+    if (!adRef.current || pushedRef.current || isDev || !showGoolgleAds) return;
 
     try {
+      // @ts-ignore
       (window.adsbygoogle = window.adsbygoogle || []).push({});
       pushedRef.current = true;
     } catch (e) {
       console.error('Adsense error:', e);
     }
-  }, [slot]);
+  }, [slot, isDev, showGoolgleAds]);
 
+  if (!showGoolgleAds) {
+    return null;
+  }
+
+  if (isDev) {
+    // Placeholder for dev / localhost
+    return (
+      <div
+        style={{
+          background: '#eee',
+          border: '1px dashed #ccc',
+          color: '#888',
+          textAlign: 'center',
+          lineHeight: style.height ? `${style.height}px` : '150px',
+          ...style,
+        }}
+      >
+        Ad Placeholder
+      </div>
+    );
+  }
+
+  // Real AdSense ad for production
   return (
     <ins
       className="adsbygoogle"

--- a/src/common-components/google-ad-slot.jsx
+++ b/src/common-components/google-ad-slot.jsx
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Google AdSense ad slot component
+ * @param {Object} props
+ * @param {string} props.slot - The AdSense ad slot ID.
+ * @param {'auto' | 'fluid'} [props.format='auto'] - The ad format type.
+ * @param {string} [props.layoutKey] - Optional AdSense layout key (used for in-feed ads).
+ * @param {React.CSSProperties} [props.style] - Inline style overrides for the <ins> element.
+ */
+export function GoogleAdSlot({ slot, format = 'auto', layoutKey, style = {} }) {
+  const adRef = useRef(null);
+  const pushedRef = useRef(false); // track if adsbygoogle.push was called
+
+  useEffect(() => {
+    if (!adRef.current || pushedRef.current) return;
+
+    try {
+      (window.adsbygoogle = window.adsbygoogle || []).push({});
+      pushedRef.current = true;
+    } catch (e) {
+      console.error('Adsense error:', e);
+    }
+  }, [slot]);
+
+  return (
+    <ins
+      className="adsbygoogle"
+      style={{ display: 'block', ...style }}
+      data-ad-client="ca-pub-3810029603871683"
+      data-ad-slot={slot}
+      data-ad-format={format}
+      {...(layoutKey ? { 'data-ad-layout-key': layoutKey } : {})}
+      ref={adRef}
+    />
+  );
+}
+
+GoogleAdSlot.propTypes = {
+  slot: PropTypes.string.isRequired,
+  format: PropTypes.oneOf(['auto', 'fluid']),
+  layoutKey: PropTypes.string,
+  style: PropTypes.object,
+};

--- a/src/common-components/google-ad-slot.jsx
+++ b/src/common-components/google-ad-slot.jsx
@@ -17,7 +17,10 @@ export function GoogleAdSlot({ slot, format = 'auto', layoutKey, style = {} }) {
   const adRef = useRef(null);
   const pushedRef = useRef(false); // track if adsbygoogle.push was called
 
-  const isDev = import.meta.env.DEV || import.meta.env.VITE_IS_DEV;
+  const isDev = import.meta.env.DEV ||
+    import.meta.env.VITE_IS_DEV ||
+    !location.hostname.includes('clearsky.app');
+
   const showGoolgleAds = useFeatureFlag('google-ads');
 
   useEffect(() => {
@@ -37,7 +40,7 @@ export function GoogleAdSlot({ slot, format = 'auto', layoutKey, style = {} }) {
   }
 
   if (isDev) {
-    // Placeholder for dev / localhost
+    // Placeholder for dev/ pr / localhost
     return (
       <div
         style={{

--- a/src/common-components/google-ad-slot.jsx
+++ b/src/common-components/google-ad-slot.jsx
@@ -18,8 +18,7 @@ export function GoogleAdSlot({ slot, format = 'auto', layoutKey, style = {} }) {
   const pushedRef = useRef(false); // track if adsbygoogle.push was called
 
   const isDev = import.meta.env.DEV || import.meta.env.VITE_IS_DEV;
-  // const showGoolgleAds = useFeatureFlag('google-ads');
-  const showGoolgleAds = true;
+  const showGoolgleAds = useFeatureFlag('google-ads');
 
   useEffect(() => {
     if (!adRef.current || pushedRef.current || isDev || !showGoolgleAds) return;

--- a/src/common-components/google-ad-slot.jsx
+++ b/src/common-components/google-ad-slot.jsx
@@ -21,10 +21,10 @@ export function GoogleAdSlot({ slot, format = 'auto', layoutKey, style = {} }) {
     import.meta.env.VITE_IS_DEV ||
     !location.hostname.includes('clearsky.app');
 
-  const showGoolgleAds = useFeatureFlag('google-ads');
+  const showGoogleAds = useFeatureFlag('google-ads');
 
   useEffect(() => {
-    if (!adRef.current || pushedRef.current || isDev || !showGoolgleAds) return;
+    if (!adRef.current || pushedRef.current || isDev || !showGoogleAds) return;
 
     try {
       // @ts-ignore
@@ -33,9 +33,9 @@ export function GoogleAdSlot({ slot, format = 'auto', layoutKey, style = {} }) {
     } catch (e) {
       console.error('Adsense error:', e);
     }
-  }, [slot, isDev, showGoolgleAds]);
+  }, [slot, isDev, showGoogleAds]);
 
-  if (!showGoolgleAds) {
+  if (!showGoogleAds) {
     return null;
   }
 

--- a/src/common-components/progressive-render.jsx
+++ b/src/common-components/progressive-render.jsx
@@ -5,6 +5,7 @@ import { GoogleAdSlot } from './google-ad-slot';
 
 const INITIAL_SIZE = 20;
 const GROW_BLOCK_SIZE = 29;
+const AD_FREQUENCY = 35;
 
 /**
  * @template ItemType
@@ -20,7 +21,7 @@ export function ProgressiveRender(props) {
     <>
       {props.items.slice(0, showSize).map((item, index) => {
         const entry = cloneElement(props.renderItem(item), { key: index });
-        if (index % 10 === 0 && index > 0) {
+        if (index % AD_FREQUENCY === 0 && index > 0) {
           return (
             <GoogleAdSlot
               key={`ad-${index}-prog-9114105783`}

--- a/src/common-components/progressive-render.jsx
+++ b/src/common-components/progressive-render.jsx
@@ -19,7 +19,7 @@ export function ProgressiveRender({ items, renderItem }) {
 
   const elements = items.slice(0, showSize).flatMap((item, index) => {
     const entryElement = renderItem(item);
-    const keyBase = entryElement.key ?? index;
+    const keyBase = index;
 
     const result = [
       cloneElement(entryElement, { key: keyBase })
@@ -45,7 +45,7 @@ export function ProgressiveRender({ items, renderItem }) {
           rootMargin="0px 0px 300px 0px"
           onVisible={() => setListSize(listSize + GROW_BLOCK_SIZE)}
         >
-          {result}
+          <>{result}</>
         </Visible>
       );
     }

--- a/src/common-components/progressive-render.jsx
+++ b/src/common-components/progressive-render.jsx
@@ -13,44 +13,45 @@ const AD_FREQUENCY = 35;
  * Given a list of items, only renders the first 20 by default,
  * and then more whenever the last item is close to being on screen
  */
-export function ProgressiveRender(props) {
+export function ProgressiveRender({ items, renderItem }) {
   const [listSize, setListSize] = useState(INITIAL_SIZE);
-  const showSize = Math.min(props.items.length, listSize);
+  const showSize = Math.min(items.length, listSize);
 
-  return (
-    <>
-      {props.items.slice(0, showSize).map((item, index) => {
-        const entry = cloneElement(props.renderItem(item), { key: index });
-        if (index % AD_FREQUENCY === 0 && index > 0) {
-          return (
-            <GoogleAdSlot
-              key={`ad-${index}-prog-9114105783`}
-              slot="9114105783"
-              format="fluid"
-              layoutKey="-fb+5w+4e-db+86"
-            />
-          );
-        }
-        return index < showSize - 1 ? (
-          entry
-        ) : (
-          <Visible
-            key={index}
-            rootMargin="0px 0px 300px 0px"
-            onVisible={handleBottomVisible}
-          >
-            {entry}
-          </Visible>
-        );
-      })}
-    </>
-  );
+  const elements = items.slice(0, showSize).flatMap((item, index) => {
+    const entryElement = renderItem(item);
+    const keyBase = entryElement.key ?? index;
 
-  function handleBottomVisible() {
-    const incrementListSize = listSize + GROW_BLOCK_SIZE;
-    setListSize(incrementListSize);
-    if (incrementListSize > props.items.length) {
-      // TODO: control fetch more from here?
+    const result = [
+      cloneElement(entryElement, { key: keyBase })
+    ];
+
+    // Insert ad after every AD_FREQUENCY items
+    if (index > 0 && index % AD_FREQUENCY === 0) {
+      result.push(
+        <GoogleAdSlot
+          key={`ad-${index}-prog-9114105783`}
+          slot="9114105783"
+          format="fluid"
+          layoutKey="-fb+5w+4e-db+86"
+        />
+      );
     }
-  }
+
+    // If this is the last item in the slice, wrap in Visible
+    if (index === showSize - 1) {
+      return (
+        <Visible
+          key={`visible-${keyBase}`}
+          rootMargin="0px 0px 300px 0px"
+          onVisible={() => setListSize(listSize + GROW_BLOCK_SIZE)}
+        >
+          {result}
+        </Visible>
+      );
+    }
+
+    return result;
+  });
+
+  return <>{elements}</>;
 }

--- a/src/common-components/progressive-render.jsx
+++ b/src/common-components/progressive-render.jsx
@@ -1,6 +1,7 @@
 // @ts-check
 import { useState, cloneElement } from 'react';
 import { Visible } from './visible';
+import { GoogleAdSlot } from './google-ad-slot';
 
 const INITIAL_SIZE = 20;
 const GROW_BLOCK_SIZE = 29;
@@ -19,7 +20,16 @@ export function ProgressiveRender(props) {
     <>
       {props.items.slice(0, showSize).map((item, index) => {
         const entry = cloneElement(props.renderItem(item), { key: index });
-
+        if (index % 10 === 0 && index > 0) {
+          return (
+            <GoogleAdSlot
+              key={`ad-${index}-prog-9114105783`}
+              slot="9114105783"
+              format="fluid"
+              layoutKey="-fb+5w+4e-db+86"
+            />
+          );
+        }
         return index < showSize - 1 ? (
           entry
         ) : (

--- a/src/detail-panels/account-header/account-extra-info.css
+++ b/src/detail-panels/account-header/account-extra-info.css
@@ -1,7 +1,3 @@
-.account-extra-info {
-  padding-left: 0.5em;
-}
-
 .text-multi-line {
   margin-top: 0.5em;
 }

--- a/src/detail-panels/account-header/account-extra-info.jsx
+++ b/src/detail-panels/account-header/account-extra-info.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 
 import { ContentCopy } from '@mui/icons-material';
-import { Button } from '@mui/material';
+import { Box, Button } from '@mui/material';
 import { unwrapShortDID } from '../../api';
 import { useHandleHistory } from '../../api/handle-history';
 import { FullDID } from '../../common-components/full-short';
@@ -12,6 +12,7 @@ import { useAccountResolver } from '../account-resolver';
 import './account-extra-info.css';
 import { HandleHistory } from './handle-history';
 import { PDSName } from './handle-history/pds-name';
+import { FirstPartyAd } from '../../common-components/first-party-ad';
 
 /**
  * @param {{
@@ -26,32 +27,35 @@ export function AccountExtraInfo({ className, onInfoClick, ...rest }) {
   const handleHistory = handleHistoryQuery.data?.handle_history;
   return (
     <div className={'account-extra-info ' + (className || '')} {...rest}>
-      <div className="close-opt" onClick={onInfoClick}>
-        &times;
-      </div>
-      <div className="bio-section">
-        {!account?.description ? undefined : (
-          <MultilineFormatted text={account?.description} />
-        )}
-      </div>
-      <div className="did-section">
-        <DidWithCopyButton
-          shortDID={account?.shortDID}
-          handleHistory={handleHistory}
-        />
-      </div>
-      <div className="handle-history-section">
-        {!handleHistory ? undefined : (
-          <>
-            <span className="handle-history-title">
-              {localise('registration and history:', {
-                uk: 'реєстрація та важливі події:',
-              })}
-            </span>
-            <HandleHistory handleHistory={handleHistory} />
-          </>
-        )}
-      </div>
+      <Box sx={{ pl: '0.5em' }}>
+        <div className="close-opt" onClick={onInfoClick}>
+          &times;
+        </div>
+        <div className="bio-section">
+          {!account?.description ? undefined : (
+            <MultilineFormatted text={account?.description} />
+          )}
+        </div>
+        <div className="did-section">
+          <DidWithCopyButton
+            shortDID={account?.shortDID}
+            handleHistory={handleHistory}
+          />
+        </div>
+        <div className="handle-history-section">
+          {!handleHistory ? undefined : (
+            <>
+              <span className="handle-history-title">
+                {localise('registration and history:', {
+                  uk: 'реєстрація та важливі події:',
+                })}
+              </span>
+              <HandleHistory handleHistory={handleHistory} />
+            </>
+          )}
+        </div>
+      </Box>
+      <FirstPartyAd placementId="447632" size="responsiveBanner" />
     </div>
   );
 }

--- a/src/detail-panels/account-header/account-extra-info.jsx
+++ b/src/detail-panels/account-header/account-extra-info.jsx
@@ -55,7 +55,9 @@ export function AccountExtraInfo({ className, onInfoClick, ...rest }) {
           )}
         </div>
       </Box>
-      <FirstPartyAd placementId="447632" size="responsiveBanner" />
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <FirstPartyAd placementId="447632" size="responsiveBanner" />
+      </Box>
     </div>
   );
 }

--- a/src/detail-panels/account-header/account-extra-info.jsx
+++ b/src/detail-panels/account-header/account-extra-info.jsx
@@ -56,7 +56,7 @@ export function AccountExtraInfo({ className, onInfoClick, ...rest }) {
         </div>
       </Box>
       <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-        <FirstPartyAd placementId="447632" size="responsiveBanner" />
+        <FirstPartyAd placementId="338957" size="responsiveBanner" />
       </Box>
     </div>
   );

--- a/src/detail-panels/account-header/account-extra-info.jsx
+++ b/src/detail-panels/account-header/account-extra-info.jsx
@@ -13,6 +13,7 @@ import './account-extra-info.css';
 import { HandleHistory } from './handle-history';
 import { PDSName } from './handle-history/pds-name';
 import { FirstPartyAd } from '../../common-components/first-party-ad';
+import { GoogleAdSlot } from '../../common-components/google-ad-slot';
 
 /**
  * @param {{
@@ -55,8 +56,13 @@ export function AccountExtraInfo({ className, onInfoClick, ...rest }) {
           )}
         </div>
       </Box>
-      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+      <Box sx={{ display: 'flex', justifyContent: 'center', flexDirection: 'column' }}>
         <FirstPartyAd placementId="338957" size="responsiveBanner" />
+        <GoogleAdSlot
+          slot="9114105783"
+          format="fluid"
+          layoutKey="-fb+5w+4e-db+86"
+        />
       </Box>
     </div>
   );

--- a/src/detail-panels/account-header/account-header.jsx
+++ b/src/detail-panels/account-header/account-header.jsx
@@ -135,10 +135,10 @@ export function AccountHeader({ className }) {
                   position: 'absolute',
                   top: 0,
                   right: 0,
-                  display: { xs: 'none', md: 'block' },
+                  display: { xs: 'none', sm: 'block' },
                 }}
               >
-                <FirstPartyAd placementId="764383" size="banner" />
+                <FirstPartyAd placementId="326541" size="banner" />
               </Box>
             </Box>
 

--- a/src/detail-panels/account-header/account-header.jsx
+++ b/src/detail-panels/account-header/account-header.jsx
@@ -10,10 +10,11 @@ import { FullHandle } from '../../common-components/full-short';
 
 import './account-header.css';
 import { localise } from '../../localisation';
-import { Button } from '@mui/material';
+import { Box, Button } from '@mui/material';
 import { useAccountResolver } from '../account-resolver';
 import { useHandleHistory } from '../../api/handle-history';
 import { usePlacement } from '../../api/placement';
+import { FirstPartyAd } from '../../common-components/first-party-ad';
 
 /**
  * @param {{
@@ -94,33 +95,54 @@ export function AccountHeader({ className }) {
                 </span>
               )}
             </span>
-            <span className="account-handle">
-              {!resolved.data?.displayName ? (
-                <>
-                  <span className="account-handle-at-empty"> </span>
-                </>
-              ) : (
-                <>
-                  <span className="account-handle-at">@</span>
-                  <a
-                    href={`https://bsky.app/profile/${unwrapShortHandle(
-                      resolved.data?.shortHandle
-                    )}`}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    <FullHandle shortHandle={resolved.data?.shortHandle} />
-                  </a>
-                </>
-              )}
-              {placement && (
-                <div className="account-place-number">User #{placement}</div>
-              )}
-            </span>
-            <Button
-              className="history-toggle"
-              variant="text"
+
+            <Box
+              sx={{
+                display: 'flex',
+                position: 'relative',
+                alignItems: 'start',
+              }}
             >
+              <span className="account-handle">
+                <div>
+                  {!resolved.data?.displayName ? (
+                    <>
+                      <span className="account-handle-at-empty"> </span>
+                    </>
+                  ) : (
+                    <>
+                      <span className="account-handle-at">@</span>
+                      <a
+                        href={`https://bsky.app/profile/${unwrapShortHandle(
+                          resolved.data?.shortHandle
+                        )}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        <FullHandle shortHandle={resolved.data?.shortHandle} />
+                      </a>
+                    </>
+                  )}
+                  {placement && (
+                    <div className="account-place-number">
+                      User #{placement}
+                    </div>
+                  )}
+                </div>
+              </span>
+              <Box
+                sx={{
+                  position: 'absolute',
+                  top: 0,
+                  right: 0,
+                  display: { xs: 'none', md: 'block' },
+                }}
+              >
+                <FirstPartyAd placementId="764383" size="banner" />
+              </Box>
+            </Box>
+
+            <Button className="history-toggle" variant="text">
               {firstHandleChangeTimestamp ? (
                 <FormatTimestamp
                   timestamp={firstHandleChangeTimestamp}

--- a/src/detail-panels/block-panel-generic/list-view.jsx
+++ b/src/detail-panels/block-panel-generic/list-view.jsx
@@ -3,6 +3,7 @@ import { FormatTimestamp } from '../../common-components/format-timestamp';
 import { ProgressiveRender } from '../../common-components/progressive-render';
 import { AccountShortEntry } from '../../common-components/account-short-entry';
 import { localise } from '../../localisation';
+import { GoogleAdSlot } from '../../common-components/google-ad-slot';
 
 /**
  * @param {{
@@ -15,6 +16,11 @@ export function ListView({ blocklist }) {
       <ProgressiveRender
         items={blocklist}
         renderItem={(item) => <ListViewEntry {...item} />}
+      />
+      <GoogleAdSlot
+        slot="9114105783"
+        format="fluid"
+        layoutKey="-fb+5w+4e-db+86"
       />
     </ul>
   );

--- a/src/detail-panels/history/search/render-search-results.jsx
+++ b/src/detail-panels/history/search/render-search-results.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { RenderPost } from '../post/render-post';
+import { GoogleAdSlot } from '../../../common-components/google-ad-slot';
 
 /**
  * @param {{
@@ -11,16 +12,41 @@ import { RenderPost } from '../post/render-post';
  */
 export function RenderSearchResults({ rankedPosts, maxRenderCount }) {
   const postElements = [];
-  const renderCount = !maxRenderCount ? rankedPosts.length : Math.min(maxRenderCount, rankedPosts.length);
+  const renderCount = !maxRenderCount
+    ? rankedPosts.length
+    : Math.min(maxRenderCount, rankedPosts.length);
+  let isAdLoaded = false;
   for (let i = 0; i < renderCount; i++) {
     const { rank, post, textHighlights, textLightHighlights } = rankedPosts[i];
     postElements.push(
-      <RenderPost key={post.uri}
-        className='history-post-entry'
+      <RenderPost
+        key={post.uri}
+        className="history-post-entry"
         disableEmbedQT={(level) => level > 5}
         post={post}
         textHighlights={textHighlights}
         textLightHighlights={textLightHighlights}
+      />
+    );
+    if (i % 10 === 0 && i > 0) {
+      isAdLoaded = true;
+      postElements.push(
+        <GoogleAdSlot
+          key={`ad-${i}-9114105783`}
+          slot="9114105783"
+          format="fluid"
+          layoutKey="-fb+5w+4e-db+86"
+        />
+      );
+    }
+  }
+  if (!isAdLoaded) {
+    postElements.push(
+      <GoogleAdSlot
+        key={`ad-end-9114105783`}
+        slot="9114105783"
+        format="fluid"
+        layoutKey="-fb+5w+4e-db+86"
       />
     );
   }

--- a/src/detail-panels/history/search/render-search-results.jsx
+++ b/src/detail-panels/history/search/render-search-results.jsx
@@ -4,6 +4,8 @@ import React from 'react';
 import { RenderPost } from '../post/render-post';
 import { GoogleAdSlot } from '../../../common-components/google-ad-slot';
 
+const AD_FREQUENCY = 10;
+
 /**
  * @param {{
  *  rankedPosts: ReturnType<typeof import('./apply-search').applySearch>,
@@ -28,7 +30,7 @@ export function RenderSearchResults({ rankedPosts, maxRenderCount }) {
         textLightHighlights={textLightHighlights}
       />
     );
-    if (i % 10 === 0 && i > 0) {
+    if (i % AD_FREQUENCY === 0 && i > 0) {
       isAdLoaded = true;
       postElements.push(
         <GoogleAdSlot

--- a/src/detail-panels/labeled/index.jsx
+++ b/src/detail-panels/labeled/index.jsx
@@ -7,6 +7,7 @@ import { AccountShortEntry } from '../../common-components/account-short-entry';
 import { FormatTimestamp } from '../../common-components/format-timestamp';
 import { useAccountResolver } from '../account-resolver';
 import './labeled.css';
+import { GoogleAdSlot } from '../../common-components/google-ad-slot';
 
 /**
  * @param {{
@@ -75,14 +76,31 @@ function LabeledListItem({ cts, val, src }) {
 function LabeledList({ labels }) {
   return (
     <ul className="labeled-view">
-      {labels.map(({ src, cts, val }) => (
-        <LabeledListItem
-          key={`${src}-${val}-${cts}`}
-          src={src}
-          cts={cts}
-          val={val}
-        />
-      ))}
+      {labels.map(({ src, cts, val }, i) => {
+        if (i % 10 === 0 && i > 0) {
+          return (
+            <GoogleAdSlot
+              key={`ad-${i}-9114105783`}
+              slot="9114105783"
+              format="fluid"
+              layoutKey="-fb+5w+4e-db+86"
+            />
+          );
+        }
+        return (
+          <LabeledListItem
+            key={`${src}-${val}-${cts}`}
+            src={src}
+            cts={cts}
+            val={val}
+          />
+        );
+      })}
+      <GoogleAdSlot
+        slot="9114105783"
+        format="fluid"
+        layoutKey="-fb+5w+4e-db+86"
+      />
     </ul>
   );
 }
@@ -115,7 +133,14 @@ export default function LabeledPanel() {
           {labels?.length ? (
             <LabeledList labels={labels} />
           ) : (
-            <div className="labeled-view no-labels">No labels</div>
+            <div className="labeled-view no-labels">
+              <div>No labels</div>
+              <GoogleAdSlot
+                slot="9114105783"
+                format="fluid"
+                layoutKey="-fb+5w+4e-db+86"
+              />
+            </div>
           )}
         </>
       )}

--- a/src/detail-panels/labeled/index.jsx
+++ b/src/detail-panels/labeled/index.jsx
@@ -66,6 +66,8 @@ function LabeledListItem({ cts, val, src }) {
   );
 }
 
+const AD_FREQUENCY = 10;
+
 /**
  * @param {{
  * labels: { cts: string, val: string,uri:string,src:string }[]
@@ -77,7 +79,7 @@ function LabeledList({ labels }) {
   return (
     <ul className="labeled-view">
       {labels.map(({ src, cts, val }, i) => {
-        if (i % 10 === 0 && i > 0) {
+        if (i % AD_FREQUENCY === 0 && i > 0) {
           return (
             <GoogleAdSlot
               key={`ad-${i}-9114105783`}

--- a/src/detail-panels/labeled/index.jsx
+++ b/src/detail-panels/labeled/index.jsx
@@ -107,7 +107,6 @@ export function LabeledList({ labels }) {
   );
 }
 
-
 /**
  * @this {never}
  */

--- a/src/detail-panels/labeled/index.jsx
+++ b/src/detail-panels/labeled/index.jsx
@@ -75,12 +75,17 @@ const AD_FREQUENCY = 10;
  *
  * @returns {JSX.Element}
  */
-function LabeledList({ labels }) {
+export function LabeledList({ labels }) {
   return (
     <ul className="labeled-view">
-      {labels.map(({ src, cts, val }, i) => {
-        if (i % AD_FREQUENCY === 0 && i > 0) {
-          return (
+      {(labels || []).flatMap(({ src, cts, val }, i) => {
+        const elements = [
+          <LabeledListItem key={`${src}-${val}-${cts}`} src={src} cts={cts} val={val} />
+        ];
+
+        // Insert ad after every AD_FREQUENCY items
+        if (i > 0 && i % AD_FREQUENCY === 0) {
+          elements.push(
             <GoogleAdSlot
               key={`ad-${i}-9114105783`}
               slot="9114105783"
@@ -89,16 +94,11 @@ function LabeledList({ labels }) {
             />
           );
         }
-        return (
-          <LabeledListItem
-            key={`${src}-${val}-${cts}`}
-            src={src}
-            cts={cts}
-            val={val}
-          />
-        );
+
+        return elements;
       })}
       <GoogleAdSlot
+        key="ad-end-9114105783"
         slot="9114105783"
         format="fluid"
         layoutKey="-fb+5w+4e-db+86"
@@ -106,6 +106,7 @@ function LabeledList({ labels }) {
     </ul>
   );
 }
+
 
 /**
  * @this {never}

--- a/src/detail-panels/layout.css
+++ b/src/detail-panels/layout.css
@@ -15,6 +15,7 @@
   display: flex;
   width: 100%;
   flex-direction: column;
+  height: 100%;
 }
 
 .layout .ad-lane {
@@ -57,7 +58,7 @@
   }
 
   .account-tabs-content {
-    /* max-height: 80em; */
+    height: 100%;
     overflow-y: auto;
     scroll-behavior: smooth;
   }
@@ -81,9 +82,10 @@
 }
 
 .account-extra-info {
-  height: calc(100% - 200px);
+  height: 100%;
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
 }
 
 .account-extra-info .did-section .copy-did {
@@ -200,6 +202,7 @@
 
 .account-tabs-content {
   border-left: none;
+  height: 100%;
 }
 
 .account-tabs-content .account-tab {
@@ -210,6 +213,7 @@
 }
 
 .account-tabs-content .account-tab-selected {
+  height: 100%;
   z-index: 10;
   opacity: 1;
   pointer-events: auto;
@@ -269,7 +273,6 @@
 @media (width <= 800px) {
   .layout {
     flex-direction: column;
-    position: relative;
   }
 
   .account-tabs-handles {

--- a/src/detail-panels/layout.css
+++ b/src/detail-panels/layout.css
@@ -273,6 +273,7 @@
 @media (width <= 800px) {
   .layout {
     flex-direction: column;
+    position: relative;
   }
 
   .account-tabs-handles {

--- a/src/detail-panels/layout.jsx
+++ b/src/detail-panels/layout.jsx
@@ -13,6 +13,7 @@ import { useAccountResolver } from './account-resolver';
 import { useSpamStatus } from '../api/spam-status';
 import { useFeatureFlag } from '../api/featureFlags';
 import { ProfileSpamBanner } from './profile/profile-spam-banner';
+import { GoogleAdSlot } from '../common-components/google-ad-slot';
 
 /**
  *
@@ -28,7 +29,9 @@ export function AccountLayout() {
 
   return (
     <div className="layout">
-      <div className="ad-lane"></div>
+      <div className="ad-lane">
+        <GoogleAdSlot slot="4524958237" />
+      </div>
       <div className="main-content">
         <Donate />
         <div className="detail-container">
@@ -45,7 +48,9 @@ export function AccountLayout() {
           </div>
         </div>
       </div>
-      <div className="ad-lane"></div>
+      <div className="ad-lane">
+        {/* <GoogleAdSlot slot="4420483623" /> */}
+      </div>
     </div>
   );
 }

--- a/src/detail-panels/layout.jsx
+++ b/src/detail-panels/layout.jsx
@@ -30,7 +30,7 @@ export function AccountLayout() {
   return (
     <div className="layout">
       <div className="ad-lane">
-        <GoogleAdSlot slot="4524958237" />
+        <GoogleAdSlot slot="4524958237" style={{ height: '100%' }} />
       </div>
       <div className="main-content">
         <Donate />
@@ -49,7 +49,7 @@ export function AccountLayout() {
         </div>
       </div>
       <div className="ad-lane">
-        {/* <GoogleAdSlot slot="4420483623" /> */}
+        <GoogleAdSlot slot="4420483623" style={{ height: '100%' }} />
       </div>
     </div>
   );

--- a/src/detail-panels/lists/list-view.jsx
+++ b/src/detail-panels/lists/list-view.jsx
@@ -12,6 +12,7 @@ import './list-view.css';
 import { ProgressiveRender } from '../../common-components/progressive-render';
 import { ConditionalAnchor } from '../../common-components/conditional-anchor';
 import { useResolveHandleOrDid } from '../../api';
+import { GoogleAdSlot } from '../../common-components/google-ad-slot';
 
 /**
  * @param {{
@@ -28,6 +29,11 @@ export function ListView({ className, list }) {
       <ProgressiveRender
         items={list || []}
         renderItem={(entry) => <ListViewEntry entry={entry} />}
+      />
+      <GoogleAdSlot
+        slot="9114105783"
+        format="fluid"
+        layoutKey="-fb+5w+4e-db+86"
       />
     </ul>
   );

--- a/src/detail-panels/packs/pack-view.jsx
+++ b/src/detail-panels/packs/pack-view.jsx
@@ -6,6 +6,8 @@ import './list-packs.css';
 import { ConditionalAnchor } from '../../common-components/conditional-anchor';
 import { GoogleAdSlot } from '../../common-components/google-ad-slot';
 
+const AD_FREQUENCY = 35;
+
 /**
  * @param {{
  *  className?: string,
@@ -18,7 +20,7 @@ export function PackView({ packs, className = '' }) {
       {packs &&
         packs?.length > 0 &&
         packs.map((pack, i) => {
-          if (i % 10 === 0 && i > 0) {
+          if (i % AD_FREQUENCY === 0 && i > 0) {
             return (
               <GoogleAdSlot
                 key={`ad-${i}-9114105783`}

--- a/src/detail-panels/packs/pack-view.jsx
+++ b/src/detail-panels/packs/pack-view.jsx
@@ -14,31 +14,38 @@ const AD_FREQUENCY = 35;
  *  packs?: PackListEntry[]
  * }}_
  */
-export function PackView({ packs, className = '' }) {
+export function PackView({ packs = [], className = '' }) {
   return (
-    <ul className={'packs-as-pack-view ' + (className || '')}>
-      {packs &&
-        packs?.length > 0 &&
-        packs.map((pack, i) => {
-          if (i % AD_FREQUENCY === 0 && i > 0) {
-            return (
-              <GoogleAdSlot
-                key={`ad-${i}-9114105783`}
-                slot="9114105783"
-                format="fluid"
-                layoutKey="-fb+5w+4e-db+86"
-              />
-            );
-          }
-          return <PackViewEntry key={i} entry={pack} />;
-        })}
+    <ul className={`packs-as-pack-view ${className}`}>
+      {packs.flatMap((pack, i) => {
+        const elements = [<PackViewEntry key={`pack-${pack.did}-${pack.created_date}`} entry={pack} />];
+
+        // Insert ad after every AD_FREQUENCY items
+        if (i > 0 && i % AD_FREQUENCY === 0) {
+          elements.push(
+            <GoogleAdSlot
+              key={`ad-${pack.did}-9114105783`}
+              slot="9114105783"
+              format="fluid"
+              layoutKey="-fb+5w+4e-db+86"
+            />
+          );
+        }
+
+        return elements;
+      })}
+
+      {/* Ensure a final ad at the end */}
       <GoogleAdSlot
+        key="ad-end-9114105783"
         slot="9114105783"
         format="fluid"
         layoutKey="-fb+5w+4e-db+86"
       />
     </ul>
   );
+
+
 
   /**
    * @param {{
@@ -92,18 +99,18 @@ export function PackView({ packs, className = '' }) {
           style={
             !avatarUrl
               ? {
-                  background: 'none',
-                  color: 'cornflowerblue',
-                  textAlign: 'center',
-                  transform: 'scale(1.5)',
-                }
+                background: 'none',
+                color: 'cornflowerblue',
+                textAlign: 'center',
+                transform: 'scale(1.5)',
+              }
               : {
-                  backgroundPosition: 'center',
-                  color: 'transparent',
-                  borderRadius: '200%',
-                  backgroundImage: `url(${avatarUrl})`,
-                  animationDelay: '10s',
-                }
+                backgroundPosition: 'center',
+                color: 'transparent',
+                borderRadius: '200%',
+                backgroundImage: `url(${avatarUrl})`,
+                animationDelay: '10s',
+              }
           }
         >
           ⓓ

--- a/src/detail-panels/packs/pack-view.jsx
+++ b/src/detail-panels/packs/pack-view.jsx
@@ -45,8 +45,6 @@ export function PackView({ packs = [], className = '' }) {
     </ul>
   );
 
-
-
   /**
    * @param {{
    *  className?: string,

--- a/src/detail-panels/packs/pack-view.jsx
+++ b/src/detail-panels/packs/pack-view.jsx
@@ -4,6 +4,7 @@ import { FormatTimestamp } from '../../common-components/format-timestamp';
 import { useResolveDidToProfile } from '../../api/resolve/did-to-profile';
 import './list-packs.css';
 import { ConditionalAnchor } from '../../common-components/conditional-anchor';
+import { GoogleAdSlot } from '../../common-components/google-ad-slot';
 
 /**
  * @param {{
@@ -16,7 +17,24 @@ export function PackView({ packs, className = '' }) {
     <ul className={'packs-as-pack-view ' + (className || '')}>
       {packs &&
         packs?.length > 0 &&
-        packs.map((pack, i) => <PackViewEntry key={i} entry={pack} />)}
+        packs.map((pack, i) => {
+          if (i % 10 === 0 && i > 0) {
+            return (
+              <GoogleAdSlot
+                key={`ad-${i}-9114105783`}
+                slot="9114105783"
+                format="fluid"
+                layoutKey="-fb+5w+4e-db+86"
+              />
+            );
+          }
+          return <PackViewEntry key={i} entry={pack} />;
+        })}
+      <GoogleAdSlot
+        slot="9114105783"
+        format="fluid"
+        layoutKey="-fb+5w+4e-db+86"
+      />
     </ul>
   );
 

--- a/src/donate.css
+++ b/src/donate.css
@@ -22,7 +22,6 @@
 .donate-home {  
   position: relative;
   background-size: 744px;
-  margin-top: 30px;
   width: 99px;
   left: 11px;  
   height: 43px;

--- a/src/donate.css
+++ b/src/donate.css
@@ -9,11 +9,10 @@
   border-radius: 20px;
   padding: 5px 10px;
   animation: scroll-it 360s linear infinite;
-  top: 20px; 
   z-index: 100;
 }
 
-.donate{
+.donate {
   position: absolute;
   top: 16px;
   right: 16px;
@@ -23,7 +22,7 @@
 .donate-home {  
   position: relative;
   background-size: 744px;
-  margin-top: 10px;
+  margin-top: 30px;
   width: 99px;
   left: 11px;  
   height: 43px;

--- a/src/landing/home-header.jsx
+++ b/src/landing/home-header.jsx
@@ -1,9 +1,11 @@
 // @ts-check
 /// <refererence path="./types.d.ts" />
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { SearchAutoComplete } from './search-autocomplete';
 import Donate from '../common-components/donate';
+import { FirstPartyAd } from '../common-components/first-party-ad';
+import { Box } from '@mui/material';
 
 /**
  * @param {{
@@ -21,8 +23,13 @@ export function HomeHeader({ className, searchText, onSearchTextChanged, onAccou
         onSearchTextChanged={onSearchTextChanged}
         onAccountSelected={onAccountSelected}
       />
-      
-    <Donate className="donate-home"/>
+      <Box sx={{ mt: 2, display: 'flex', alignItems: 'start', justifyContent: "flex-start", flexDirection: 'row', gap: 2 }}>
+
+        <Donate className="donate-home" />
+        <Box sx={{ display: { xs: 'bloack', md: 'none' } }}>
+          <FirstPartyAd placementId="227845" size="banner" />
+        </Box>
+      </Box>
     </div>
   );
 }

--- a/src/landing/home-header.jsx
+++ b/src/landing/home-header.jsx
@@ -23,13 +23,36 @@ export function HomeHeader({ className, searchText, onSearchTextChanged, onAccou
         onSearchTextChanged={onSearchTextChanged}
         onAccountSelected={onAccountSelected}
       />
-      <Box sx={{ mt: 2, display: 'flex', alignItems: 'start', justifyContent: "flex-start", flexDirection: 'row', gap: 2 }}>
+      <Box sx={{
+        mt: 2,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: "flex-start",
+        flexDirection: 'row',
+        gap: 2,
+      }}>
 
         <Donate className="donate-home" />
-        <Box sx={{ display: { xs: 'bloack', md: 'none' } }}>
+        <Box sx={{ display: { xs: 'flex', md: 'none' } }}>
           <FirstPartyAd placementId="227845" size="banner" />
         </Box>
       </Box>
+
+
+      <Box
+        sx={{
+          mt: 2,
+          display: { xs: 'none', md: 'flex' },
+          alignItems: 'start',
+          flexDirection: 'column',
+          gap: 2,
+
+        }}
+      >
+        <FirstPartyAd placementId="447632" size="responsiveBanner" />
+        <FirstPartyAd placementId="764383" size="responsiveBanner" />
+      </Box>
+
     </div>
   );
 }

--- a/src/landing/home.css
+++ b/src/landing/home.css
@@ -3,7 +3,7 @@
   left: 0;
   top: 5px;
   width: 100%;
-  height: calc(100% - 50px);
+  height: calc(100% - 90px);
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr auto 1fr;

--- a/src/landing/home.jsx
+++ b/src/landing/home.jsx
@@ -46,13 +46,13 @@ export default function Home() {
         sx={{
           mt: 2,
           display: 'flex',
-          alignItems: 'center',
+          alignItems: 'start',
           flexDirection: 'column',
           gap: 2,
         }}
       >
-        <FirstPartyAd placementId="447632" size="responsive" />
         <FirstPartyAd placementId="447632" size="responsiveBanner" />
+        <FirstPartyAd placementId="764383" size="responsiveBanner" />
       </Box>
 
       <React.Suspense>

--- a/src/landing/home.jsx
+++ b/src/landing/home.jsx
@@ -6,10 +6,12 @@ import { unwrapShortHandle } from '../api';
 import { HomeHeader } from './home-header';
 
 import './home.css';
-import '../donate.css'
+import '../donate.css';
 import { Logo } from './logo';
 import { HomeStats } from './home-stats';
 import { About } from './about';
+import { Box } from '@mui/material';
+import { FirstPartyAd } from '../common-components/first-party-ad';
 
 export default function Home() {
   const [searchText, setSearchText] = React.useState('');
@@ -39,7 +41,19 @@ export default function Home() {
           }
         }}
       />
-      
+
+      <Box
+        sx={{
+          mt: 2,
+          display: 'flex',
+          alignItems: 'center',
+          flexDirection: 'column',
+          gap: 2,
+        }}
+      >
+        <FirstPartyAd placementId="447632" size="responsive" />
+        <FirstPartyAd placementId="447632" size="responsiveBanner" />
+      </Box>
 
       <React.Suspense>
         <HomeStats className="home-stats" />

--- a/src/landing/home.jsx
+++ b/src/landing/home.jsx
@@ -11,7 +11,6 @@ import { Logo } from './logo';
 import { HomeStats } from './home-stats';
 import { About } from './about';
 import { Box } from '@mui/material';
-import { FirstPartyAd } from '../common-components/first-party-ad';
 import { GoogleAdSlot } from '../common-components/google-ad-slot';
 
 export default function Home() {
@@ -43,30 +42,16 @@ export default function Home() {
         }}
       />
 
-      <Box
-        sx={{
-          mt: 2,
-          display: { xs: 'none', md: 'flex' },
-          alignItems: 'start',
-          flexDirection: 'column',
-          gap: 2,
-
-        }}
-      >
-        <FirstPartyAd placementId="447632" size="responsiveBanner" />
-        <FirstPartyAd placementId="764383" size="responsiveBanner" />
-      </Box>
-
 
       <React.Suspense>
         <HomeStats className="home-stats" />
       </React.Suspense>
 
       <Box sx={{
-        position: 'absolute',
-        bottom: 0,
+        position: { xs: 'fixed', sm: 'fixed' },
+        bottom: 30,
         left: 0,
-        width: '100vw',
+        width: '100%',
         height: '50px',
       }}>
 

--- a/src/landing/home.jsx
+++ b/src/landing/home.jsx
@@ -12,6 +12,7 @@ import { HomeStats } from './home-stats';
 import { About } from './about';
 import { Box } from '@mui/material';
 import { FirstPartyAd } from '../common-components/first-party-ad';
+import { GoogleAdSlot } from '../common-components/google-ad-slot';
 
 export default function Home() {
   const [searchText, setSearchText] = React.useState('');
@@ -33,9 +34,9 @@ export default function Home() {
             if (account.postID)
               navigate(
                 '/' +
-                  unwrapShortHandle(account.shortHandle) +
-                  '/history/?q=' +
-                  account.postID
+                unwrapShortHandle(account.shortHandle) +
+                '/history/?q=' +
+                account.postID
               );
             else navigate('/' + unwrapShortHandle(account.shortHandle));
           }
@@ -45,19 +46,32 @@ export default function Home() {
       <Box
         sx={{
           mt: 2,
-          display: 'flex',
+          display: { xs: 'none', md: 'flex' },
           alignItems: 'start',
           flexDirection: 'column',
           gap: 2,
+
         }}
       >
         <FirstPartyAd placementId="447632" size="responsiveBanner" />
         <FirstPartyAd placementId="764383" size="responsiveBanner" />
       </Box>
 
+
       <React.Suspense>
         <HomeStats className="home-stats" />
       </React.Suspense>
+
+      <Box sx={{
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        width: '100vw',
+        height: '50px',
+      }}>
+
+        <GoogleAdSlot slot='4420483623' style={{ height: 50 }} />
+      </Box>
     </div>
   );
 }


### PR DESCRIPTION
### Summary
This PR adds full integration for Google AdSense ads and improves the existing FirstPartyAd component. Ads now work responsively across desktop and mobile, and click tracking is implemented with proper payloads.

### Changes
- **AdSlot Component**
  - Reusable Google AdSense component with support for `auto`, `fluid`, and optional `layoutKey` for in-feed ads.
  - Development placeholder prevents 403 errors on localhost.
  - Handles single `adsbygoogle.push()` call per ad instance to avoid duplicate ad errors.

- **FirstPartyAd Component**
  - Responsive container while preserving original image size.
  - Images scale down if larger than container, maintaining aspect ratio.
  - Click tracking sends `adId` and `placementId` in the payload.

- **PropTypes & Documentation**
  - Added PropTypes and JSDoc for all ad components.
  - Ensures type safety and clarity for future development.

### Tested Ad Placements
- Vertical left and right (desktop)
- Horizontal home page (desktop)
- In-feed fluid ads
- Mobile home and profile ads

### Notes
- Real Google ads only render in production; development shows placeholders to prevent 403 errors.
- Ready for QA on staging domain with AdSense approved.
