### PR TITLE
Add Labelers Page and Labels Pages

### DIFF
--- a/src/api/labled.js
+++ b/src/api/labled.js
@@ -100,3 +100,43 @@ export function useLabeled(did, lablerDids) {
     },
   });
 }
+
+
+/**
+ * @typedef {Object} LabelerInfo
+ * @property {string} created_date
+ * @property {string|null} description
+ * @property {string} did
+ * @property {string} endpoint
+ * @property {string} name
+ */
+
+/**
+ * Fetch labelers (paginated).
+ * @param {number} page
+ * @returns {Promise<{data: LabelerInfo[]}>}
+ */
+export async function fetchLabelersPage(page = 1) {
+
+  const endpoint =
+    page === 1
+      ? `get-labelers`
+      : `get-labelers/${page}`;
+  const res = await fetchClearskyApi(
+    'v1',
+    endpoint
+  );
+  return res; // expected shape: { data: Array<LabelerInfo> }
+}
+
+/**
+ * React Query hook for fetching labelers by page
+ * @param {number} page
+ */
+export function useLabelersPage(page = 1) {
+  return useQuery({
+    queryKey: ['labelers', page],
+    queryFn: () => fetchLabelersPage(page),
+    enabled: !!page,
+  });
+}

--- a/src/api/pds.js
+++ b/src/api/pds.js
@@ -120,3 +120,31 @@ export function useUsersPerPds(pds, page = 1) {
     queryFn: () => fetchUsersPerPds(pds, page),
   });
 }
+
+/**
+ * Fetch PDS info for a given DID
+ * @param {string | undefined} did
+ * @returns {Promise<{ data: { pds: string }, identity: string }>}
+ */
+export async function fetchPdsForDid(did) {
+  if (!did) {
+    return { data: { pds: "" }, identity: "" };
+  }
+
+  return fetchClearskyApi(
+    'v1',
+    `pds/get-pds/${encodeURIComponent(did)}`
+  );
+}
+
+/**
+ * React Query hook to fetch PDS info for a DID
+ * @param {string | undefined} did
+ */
+export function usePdsForDid(did) {
+  return useQuery({
+    enabled: !!did,
+    queryKey: ['pds-for-did', did],
+    queryFn: () => fetchPdsForDid(did),
+  });
+}

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -38,6 +38,8 @@ async function showApp() {
           },
           { path: 'index.html', element: <Navigate to="/" replace /> },
           { path: 'stable/*', element: <Navigate to="/" replace /> },
+          { path: 'labelers', lazy: () => getDefaultComponent(import('./labelers/labelers')) },
+          { path: 'labelers/:label', lazy: () => getDefaultComponent(import('./labelers/label-view')) },
           {
             path: ':handle',
             lazy: () => getDefaultComponent(import('./detail-panels')),

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -45,7 +45,7 @@ async function showApp() {
             lazy: () => getDefaultComponent(import('./landing/contact')),
           },
           { path: 'labelers', lazy: () => getDefaultComponent(import('./labelers/labelers')) },
-          { path: 'labelers/:label', lazy: () => getDefaultComponent(import('./labelers/label-view')) },
+          { path: 'labelers/:did', lazy: () => getDefaultComponent(import('./labelers/label-view')) },
           {
             path: ':handle',
             lazy: () => getDefaultComponent(import('./detail-panels')),

--- a/src/labelers/label-view.jsx
+++ b/src/labelers/label-view.jsx
@@ -1,7 +1,199 @@
-import React from 'react'
+import React, { useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  Box,
+  Typography,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  IconButton,
+  useTheme,
+  useMediaQuery,
+  Card,
+  CardContent,
+  Divider,
+} from "@mui/material";
+import { useLabelerRecord } from "../api/labled";
+import { AccountShortEntry } from "../common-components/account-short-entry";
+import { useFeatureFlag } from "../api/featureFlags";
 
 export default function LabelView() {
+  const { did } = useParams();
+  const navigate = useNavigate();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+  const labelerInformationFlag = useFeatureFlag('labeler-information');
+
+  const { data, status } = useLabelerRecord(did);
+
+  const allDefinitions = data?.value.policies.labelValueDefinitions;
+
+  useEffect(() => {
+    if (!labelerInformationFlag) {
+      navigate("/");
+    }
+  }, [labelerInformationFlag, navigate]);
+
+  if (!labelerInformationFlag || status === "pending") {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <Box
+        sx={{
+          height: "100vh",
+          overflow: "auto",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "flex-start",
+          py: 4,
+          px: 2,
+        }}
+      >
+        <Box sx={{ width: "100%", maxWidth: 1200 }}>
+          {/* Header */}
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "flex-start",
+              alignItems: "center",
+              mb: 2,
+              flexWrap: "wrap",
+            }}
+          >
+            <IconButton onClick={() => navigate(-1)}>&lsaquo;</IconButton>
+
+          </Box>
+          <Typography color="error" textAlign={'center'}>
+            Labeler not active
+          </Typography>
+        </Box>
+      </Box>
+
+    );
+  }
+
   return (
-    <div>LabelView</div>
-  )
+    <Box
+      sx={{
+        height: "100vh",
+        overflow: "auto",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "flex-start",
+        py: 4,
+        px: 2,
+      }}
+    >
+      <Box sx={{ width: "100%", maxWidth: 1200 }}>
+        {/* Header */}
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            mb: 2,
+            flexWrap: "wrap",
+          }}
+        >
+          <IconButton onClick={() => navigate(-1)}>&lsaquo;</IconButton>
+          {
+            did &&
+            <AccountShortEntry account={did} />
+          }
+
+          <Typography
+            sx={{
+              fontSize: "0.8em",
+              color: "silver",
+              mb: isMobile ? 1 : 0,
+            }}
+          >
+            <i>Labeles for {did}</i>
+          </Typography>
+        </Box>
+
+        {/* Mobile: Card View */}
+        {isMobile ? (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            {!allDefinitions || allDefinitions.length === 0 ? (
+              <Typography textAlign="center">No label definitions found</Typography>
+            ) : (
+              allDefinitions.map((def) => {
+                const locale =
+                  def.locales?.find(({ lang }) => lang === "en") || def.locales?.[0];
+                return (
+                  <Card key={def.identifier} variant="outlined">
+                    <CardContent>
+                      <Typography variant="subtitle2" color="textSecondary">
+                        Name (id)
+                      </Typography>
+                      <Typography>
+                        {locale?.name || "-"} ({def.identifier})
+                      </Typography>
+
+                      <Divider sx={{ my: 1 }} />
+
+                      <Typography variant="subtitle2" color="textSecondary">
+                        Description
+                      </Typography>
+                      <Typography sx={{ fontSize: "0.9em" }}>
+                        {locale?.description || "-"}
+                      </Typography>
+                    </CardContent>
+                  </Card>
+                );
+              })
+            )}
+          </Box>
+        ) : (
+          /* Desktop: Table View */
+          <TableContainer component={Paper} sx={{ borderRadius: 2, overflow: "auto" }}>
+            <Table size="small" stickyHeader>
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={{ fontWeight: "bold", whiteSpace: "nowrap" }}>
+                    Name (id)
+                  </TableCell>
+                  <TableCell sx={{ fontWeight: "bold" }}>Description</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {!allDefinitions || allDefinitions.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={2} sx={{ textAlign: "center", py: 2 }}>
+                      No label definitions found
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  allDefinitions.map((def) => {
+                    const locale =
+                      def.locales?.find(({ lang }) => lang === "en") || def.locales?.[0];
+                    return (
+                      <TableRow key={def.identifier}>
+                        <TableCell sx={{ whiteSpace: "nowrap" }}>
+                          {locale?.name || "-"} ({def.identifier})
+                        </TableCell>
+                        <TableCell>{locale?.description || "-"}</TableCell>
+                      </TableRow>
+                    );
+                  })
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </Box>
+    </Box>
+  );
 }

--- a/src/labelers/label-view.jsx
+++ b/src/labelers/label-view.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default function LabelView() {
+  return (
+    <div>LabelView</div>
+  )
+}

--- a/src/labelers/labelers.jsx
+++ b/src/labelers/labelers.jsx
@@ -9,22 +9,27 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  Paper,
   Typography,
   CircularProgress,
   useTheme,
   useMediaQuery,
   IconButton,
   Button,
+  Card,
+  CardContent,
+  Divider,
 } from "@mui/material";
 import { useLabelersPage } from "../api/labled";
 import { AccountShortEntry } from "../common-components/account-short-entry";
+import { HydrateFallback } from "../common-components/hydrate-fallback";
+import { useFeatureFlag } from "../api/featureFlags";
 
 export default function LabelersPage() {
   const navigate = useNavigate();
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
-  const labelerInformation = true;
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+  const labelerInformationFlag = useFeatureFlag('labeler-information');
+
 
   const [page, setPage] = useState(1);
   const [allLabelers, setAllLabelers] = useState([]);
@@ -44,7 +49,7 @@ export default function LabelersPage() {
 
   // Append pages & stop if needed
   useEffect(() => {
-    if (isFetching || !labelerInformation) return;
+    if (isFetching || !labelerInformationFlag) return;
 
     if (data?.data?.length) {
       setAllLabelers((prev) => [...prev, ...data.data]);
@@ -54,16 +59,16 @@ export default function LabelersPage() {
     } else {
       setHasMore(false);
     }
-  }, [data, isFetching, labelerInformation]);
+  }, [data, isFetching, labelerInformationFlag]);
 
   useEffect(() => {
-    if (!labelerInformation) {
+    if (!labelerInformationFlag) {
       navigate("/");
     }
-  }, [labelerInformation, navigate]);
+  }, [labelerInformationFlag, navigate]);
 
-  if (!labelerInformation || (status === "pending" && page === 1)) {
-    return <>Loading...</>;
+  if (!labelerInformationFlag || (status === "pending" && page === 1)) {
+    return <HydrateFallback />;
   }
 
   if (status === "error" || data?.error) {
@@ -82,7 +87,7 @@ export default function LabelersPage() {
       onScroll={handleScroll}
       sx={{
         height: "100vh",
-        overflow: "auto",
+        overflow: 'auto',
         display: "flex",
         justifyContent: "center",
         alignItems: "flex-start",
@@ -113,94 +118,179 @@ export default function LabelersPage() {
           </Typography>
         </Box>
 
-        {/* Table */}
-        <TableContainer
-          component={Paper}
-          sx={{
-            width: "100%",
-            overflowX: "auto", // horizontal scroll on small screens
-            borderRadius: 2,
-          }}
-        >
-          <Table size="small" stickyHeader sx={{ minWidth: 800 }}>
-            <TableHead>
-              <TableRow sx={{ backgroundColor: "#ffe492" }}>
-                {["Handle", "DID", "Name", "Endpoint", "Description", "Actions"].map((head) => (
-                  <TableCell
-                    key={head}
-                    sx={{
-                      fontWeight: "bold",
-                      p: isMobile ? 0.5 : 1,
-                      fontSize: isMobile ? "0.75em" : "1em",
-                      wordBreak: "break-word",
-                      whiteSpace: "normal",
-                    }}
-                  >
-                    {head}
-                  </TableCell>
-                ))}
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {allLabelers.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={6} sx={{ textAlign: "center", py: 2 }}>
-                    No results found
-                  </TableCell>
-                </TableRow>
-              ) : (
-                allLabelers.map((labeler) => (
-                  <TableRow key={labeler.did} hover>
-                    <TableCell sx={{ p: isMobile ? 0.5 : 1, wordBreak: "break-word" }}>
-                      <AccountShortEntry account={labeler.did} />
-                    </TableCell>
-                    <TableCell sx={{ p: isMobile ? 0.5 : 1, wordBreak: "break-word" }}>
-                      {labeler.did ?? "-"}
-                    </TableCell>
-                    <TableCell sx={{ p: isMobile ? 0.5 : 1, wordBreak: "break-word" }}>
-                      {labeler.name?.trim() || "-"}
-                    </TableCell>
-                    <TableCell sx={{ p: isMobile ? 0.5 : 1, wordBreak: "break-word", color: "primary.main" }}>
-                      {labeler.endpoint ? (
-                        <a
-                          href={labeler.endpoint}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          style={{ color: "inherit", textDecoration: "none" }}
-                        >
-                          {labeler.endpoint}
-                        </a>
-                      ) : (
-                        "-"
-                      )}
-                    </TableCell>
-                    <TableCell sx={{ p: isMobile ? 0.5 : 1, wordBreak: "break-word", fontSize: isMobile ? "0.75em" : "1em", maxWidth: 800 }}>
+        {/* Mobile: Card View */}
+        {isMobile ? (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            {allLabelers.length === 0 ? (
+              <Typography textAlign="center">No results found</Typography>
+            ) : (
+              allLabelers.map((labeler) => (
+                <Card key={labeler.did} variant="outlined">
+                  <CardContent>
+                    <Typography variant="subtitle2" color="textSecondary">
+                      Handle
+                    </Typography>
+                    <AccountShortEntry account={labeler.did} />
+
+                    <Divider sx={{ my: 1 }} />
+
+                    <Typography variant="subtitle2" color="textSecondary">
+                      DID
+                    </Typography>
+                    <Typography>{labeler.did ?? "-"}</Typography>
+
+                    <Divider sx={{ my: 1 }} />
+
+                    <Typography variant="subtitle2" color="textSecondary">
+                      Name
+                    </Typography>
+                    <Typography>{labeler.name?.trim() || "-"}</Typography>
+
+                    <Divider sx={{ my: 1 }} />
+
+                    <Typography variant="subtitle2" color="textSecondary">
+                      Endpoint
+                    </Typography>
+                    {labeler.endpoint ? (
+                      <a
+                        href={labeler.endpoint}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {labeler.endpoint}
+                      </a>
+                    ) : (
+                      "-"
+                    )}
+
+                    <Divider sx={{ my: 1 }} />
+
+                    <Typography variant="subtitle2" color="textSecondary">
+                      Description
+                    </Typography>
+                    <Typography sx={{ fontSize: "0.9em" }}>
                       {labeler.description ?? "-"}
-                    </TableCell>
-                    <TableCell sx={{ p: isMobile ? 0.5 : 1, textAlign: "center" }}>
+                    </Typography>
+
+                    <Box mt={2} textAlign="center">
                       <Button
-                        sx={{ textTransform: "none", whiteSpace: 'nowrap' }}
+                        sx={{ textTransform: "none" }}
                         variant="contained"
                         onClick={() => navigate(`/labelers/${labeler.did}`)}
                       >
                         See Labels
                       </Button>
+                    </Box>
+                  </CardContent>
+                </Card>
+              ))
+            )}
+            {isFetching && hasMore && (
+              <Box sx={{ textAlign: "center", py: 2 }}>
+                <CircularProgress size={24} />
+              </Box>
+            )}
+          </Box>
+        ) : (
+          /* Desktop: Table View */
+          <TableContainer
+            sx={{
+              width: "100%",
+              overflow: 'auto',
+              borderRadius: 2,
+            }}
+          >
+            <Table size="small" stickyHeader sx={{ minWidth: 800 }}>
+              <TableHead>
+                <TableRow>
+                  {[
+                    "Handle",
+                    "DID",
+                    "Name",
+                    "Endpoint",
+                    "Description",
+                    "Actions",
+                  ].map((head) => (
+                    <TableCell key={head} sx={{
+                      fontWeight: "bold",
+                      wordBreak: "break-word",
+                      whiteSpace: "normal",
+                    }}>
+                      {head}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {allLabelers.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={6} sx={{ textAlign: "center", py: 2 }}>
+                      No results found
                     </TableCell>
                   </TableRow>
-                ))
-              )}
-              {isFetching && hasMore && (
-                <TableRow>
-                  <TableCell colSpan={6} sx={{ textAlign: "center", py: 2 }}>
-                    <CircularProgress size={24} />
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
+                ) : (
+                  allLabelers.map((labeler) => (
+                    <TableRow key={labeler.did} hover>
+                      <TableCell sx={{
+                        wordBreak: "break-word",
+                        whiteSpace: "normal",
+                        maxWidth: 300
+                      }}>
+                        <AccountShortEntry account={labeler.did} />
+                      </TableCell>
+                      <TableCell sx={{
+                        wordBreak: "break-word",
+                        whiteSpace: "normal",
+                      }}>{labeler.did ?? "-"}</TableCell>
+                      <TableCell sx={{
+                        wordBreak: "break-word",
+                        whiteSpace: "normal",
+                      }}>{labeler.name?.trim() || "-"}</TableCell>
+                      <TableCell sx={{
+                        color: "primary.main", wordBreak: "break-word",
+                        whiteSpace: "normal",
+                      }}>
+                        {labeler.endpoint ? (
+                          <a
+                            href={labeler.endpoint}
+                            target="_blank"
+                            rel="noopener noreferrer"
 
-
+                          >
+                            {labeler.endpoint}
+                          </a>
+                        ) : (
+                          "-"
+                        )}
+                      </TableCell>
+                      <TableCell sx={{
+                        wordBreak: "break-word",
+                        whiteSpace: "normal",
+                        maxWidth: 350
+                      }}>{labeler.description ?? "-"}</TableCell>
+                      <TableCell sx={{ textAlign: "center" }}>
+                        <Button
+                          sx={{ textTransform: "none", whiteSpace: "nowrap" }}
+                          variant="contained"
+                          onClick={() => navigate(`/labelers/${labeler.did}`)}
+                        >
+                          See Labels
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+                {isFetching && hasMore && (
+                  <TableRow>
+                    <TableCell colSpan={6} sx={{ textAlign: "center", py: 2 }}>
+                      <CircularProgress size={24} />
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
       </Box>
     </Box>
   );

--- a/src/labelers/labelers.jsx
+++ b/src/labelers/labelers.jsx
@@ -1,0 +1,207 @@
+import React, { useState, useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Box,
+  Container,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Typography,
+  CircularProgress,
+  useTheme,
+  useMediaQuery,
+  IconButton,
+  Button,
+} from "@mui/material";
+import { useLabelersPage } from "../api/labled";
+import { AccountShortEntry } from "../common-components/account-short-entry";
+
+export default function LabelersPage() {
+  const navigate = useNavigate();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const labelerInformation = true;
+
+  const [page, setPage] = useState(1);
+  const [allLabelers, setAllLabelers] = useState([]);
+  const [hasMore, setHasMore] = useState(true);
+  const containerRef = useRef(null);
+
+  const { data, status, isFetching } = useLabelersPage(page);
+
+  // Infinite scroll
+  const handleScroll = () => {
+    if (!containerRef.current || !hasMore) return;
+    const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
+    if (scrollTop + clientHeight >= scrollHeight - 50 && !isFetching) {
+      setPage((prev) => prev + 1);
+    }
+  };
+
+  // Append pages & stop if needed
+  useEffect(() => {
+    if (isFetching || !labelerInformation) return;
+
+    if (data?.data?.length) {
+      setAllLabelers((prev) => [...prev, ...data.data]);
+      if (data.data.length < 100) {
+        setHasMore(false);
+      }
+    } else {
+      setHasMore(false);
+    }
+  }, [data, isFetching, labelerInformation]);
+
+  useEffect(() => {
+    if (!labelerInformation) {
+      navigate("/");
+    }
+  }, [labelerInformation, navigate]);
+
+  if (!labelerInformation || (status === "pending" && page === 1)) {
+    return <>Loading...</>;
+  }
+
+  if (status === "error" || data?.error) {
+    return (
+      <Container sx={{ p: 4, textAlign: "center" }}>
+        <Typography color="error">
+          {data?.error || "Failed to load labelers"}
+        </Typography>
+      </Container>
+    );
+  }
+
+  return (
+    <Box
+      ref={containerRef}
+      onScroll={handleScroll}
+      sx={{
+        height: "100vh",
+        overflow: "auto",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "flex-start",
+        py: 4,
+        px: 2,
+      }}
+    >
+      <Box sx={{ width: "100%", maxWidth: 1200 }}>
+        {/* Header */}
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            mb: 2,
+            flexWrap: "wrap",
+          }}
+        >
+          <IconButton onClick={() => navigate(-1)}>&lsaquo;</IconButton>
+          <Typography
+            sx={{
+              fontSize: "0.8em",
+              color: "silver",
+              mb: isMobile ? 1 : 0,
+            }}
+          >
+            <i>Labeler Information</i>
+          </Typography>
+        </Box>
+
+        {/* Table */}
+        <TableContainer
+          component={Paper}
+          sx={{
+            width: "100%",
+            overflowX: "auto", // horizontal scroll on small screens
+            borderRadius: 2,
+          }}
+        >
+          <Table size="small" stickyHeader sx={{ minWidth: 800 }}>
+            <TableHead>
+              <TableRow sx={{ backgroundColor: "#ffe492" }}>
+                {["Handle", "DID", "Name", "Endpoint", "Description", "Actions"].map((head) => (
+                  <TableCell
+                    key={head}
+                    sx={{
+                      fontWeight: "bold",
+                      p: isMobile ? 0.5 : 1,
+                      fontSize: isMobile ? "0.75em" : "1em",
+                      wordBreak: "break-word",
+                      whiteSpace: "normal",
+                    }}
+                  >
+                    {head}
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {allLabelers.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} sx={{ textAlign: "center", py: 2 }}>
+                    No results found
+                  </TableCell>
+                </TableRow>
+              ) : (
+                allLabelers.map((labeler) => (
+                  <TableRow key={labeler.did} hover>
+                    <TableCell sx={{ p: isMobile ? 0.5 : 1, wordBreak: "break-word" }}>
+                      <AccountShortEntry account={labeler.did} />
+                    </TableCell>
+                    <TableCell sx={{ p: isMobile ? 0.5 : 1, wordBreak: "break-word" }}>
+                      {labeler.did ?? "-"}
+                    </TableCell>
+                    <TableCell sx={{ p: isMobile ? 0.5 : 1, wordBreak: "break-word" }}>
+                      {labeler.name?.trim() || "-"}
+                    </TableCell>
+                    <TableCell sx={{ p: isMobile ? 0.5 : 1, wordBreak: "break-word", color: "primary.main" }}>
+                      {labeler.endpoint ? (
+                        <a
+                          href={labeler.endpoint}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          style={{ color: "inherit", textDecoration: "none" }}
+                        >
+                          {labeler.endpoint}
+                        </a>
+                      ) : (
+                        "-"
+                      )}
+                    </TableCell>
+                    <TableCell sx={{ p: isMobile ? 0.5 : 1, wordBreak: "break-word", fontSize: isMobile ? "0.75em" : "1em", maxWidth: 800 }}>
+                      {labeler.description ?? "-"}
+                    </TableCell>
+                    <TableCell sx={{ p: isMobile ? 0.5 : 1, textAlign: "center" }}>
+                      <Button
+                        sx={{ textTransform: "none", whiteSpace: 'nowrap' }}
+                        variant="contained"
+                        onClick={() => navigate(`/labelers/${labeler.did}`)}
+                      >
+                        See Labels
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+              {isFetching && hasMore && (
+                <TableRow>
+                  <TableCell colSpan={6} sx={{ textAlign: "center", py: 2 }}>
+                    <CircularProgress size={24} />
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+
+
+      </Box>
+    </Box>
+  );
+}

--- a/src/landing/home-stats/home-stats-main.jsx
+++ b/src/landing/home-stats/home-stats-main.jsx
@@ -27,7 +27,7 @@ export function HomeStatsMain({
   const topBlocked = useFeatureFlag('top-blocked');
   const topBlockers = useFeatureFlag('top-blockers');
   const pdsInformation = useFeatureFlag('pds-information');
-  const labelerInformation = useFeatureFlag('labeler-information');
+  const labelerInformationFlag = useFeatureFlag('labeler-information');
 
 
   const blueButtonStyle = {
@@ -107,11 +107,11 @@ export function HomeStatsMain({
             Block Stats
           </Button>
         }{
-          labelerInformation &&
+          labelerInformationFlag &&
           <Button
             size="small"
             variant="contained"
-            onClick={() => navigate("/labeler-info")}
+            onClick={() => navigate("/labelers")}
             sx={blueButtonStyle}
           >
             Labeler Information


### PR DESCRIPTION
This PR implements the following features related to Labelers:

## 1. Labelers Page
- Fetch and display paginated labeler information using `useLabelersPage`.
- **Desktop:** Display data in a table with columns: Handle, DID, Name, Endpoint, Description, Actions.
- **Mobile:** Display data as responsive cards for better readability.
- Infinite scroll support for large datasets.
- Back navigation and header styling consistent with the app’s design.

## 2. Label Definitions View (`LabelView`)
- Fetch individual labeler records using `useLabelerRecord`.
- **Desktop:** Display label definitions in a table with columns: Name (id) | Description.
- **Mobile:** Display label definitions in responsive cards.
- Includes handling for empty datasets and loading/error states.

## Related Issues
- Fixes [#240](https://github.com/ClearskyApp06/ClearskyUI/issues/240) – Implement Labelers Page UI
- Fixes [#241](https://github.com/ClearskyApp06/ClearskyUI/issues/241) – Implement Label Definitions View UI

## Notes
- Implementation ensures consistency between mobile and desktop layouts.
- Scrollable containers added for long content.
- Reusable components like `AccountShortEntry` are used for handle rendering.