### PR TITLE
Prevent starter-pack pagination from anchoring scroll

### DIFF
--- a/src/detail-panels/packs/list-packs.css
+++ b/src/detail-panels/packs/list-packs.css
@@ -23,6 +23,11 @@ a:hover {
   text-decoration: underline;
 }
 
+.packs-as-pack-view > :last-child,
+.packs-as-pack-view + div {
+  overflow-anchor: none;
+}
+
 .account-short-entry-avatar {
   background: no-repeat center center;
   background-size: cover;

--- a/test/list-packs-scroll-anchoring.test.mjs
+++ b/test/list-packs-scroll-anchoring.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const stylesheet = await readFile(
+  new URL('../src/detail-panels/packs/list-packs.css', import.meta.url),
+  'utf8'
+);
+
+test('starter-pack pagination sentinels do not become scroll anchors', () => {
+  assert.match(
+    stylesheet,
+    /\.packs-as-pack-view\s*>\s*:last-child,\s*\.packs-as-pack-view\s*\+\s*div\s*{[^}]*overflow-anchor:\s*none;/s,
+    'starter-pack pagination sentinels must disable scroll anchoring'
+  );
+});


### PR DESCRIPTION
## Summary

- Exclude the starter-pack list’s final item/ad and pagination sentinel from scroll-anchor selection.
- Add a focused regression test for the starter-pack pagination CSS.

## Testing

- `OPENSSL_CONF=/dev/null PATH=/Users/aeziz-local/.nvm/versions/node/v22.22.3/bin:$PATH node --test test/list-packs-scroll-anchoring.test.mjs` (passed)
- `npx --no-install stylelint src/detail-panels/packs/list-packs.css` (unable to run because the managed environment denied `npx` execution)

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1009:start -->
### Verification

[Northset proof-of-pass receipt M-1009](https://northset-oss.github.io/verification-pilot/receipts/M-1009/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1009:end -->
